### PR TITLE
perf: add an option to disable the internal migration system

### DIFF
--- a/src/env-vars-check.ts
+++ b/src/env-vars-check.ts
@@ -21,6 +21,15 @@ const errors: string[] = [];
   }
 });
 
+if (
+  isUnset(process.env['HASURA_GRAPHQL_DATABASE_URL']) &&
+  !ENV.HASURA_SKIP_MIGRATIONS
+) {
+  errors.push(
+    `No value was provided for required env var HASURA_GRAPHQL_DATABASE_URL`
+  );
+}
+
 if (PROVIDERS.apple) {
   [
     'AUTH_APPLE_CLIENT_ID',

--- a/src/ts-start.ts
+++ b/src/ts-start.ts
@@ -71,8 +71,10 @@ const start = async (): Promise<void> => {
   const metadataShouldBeApplied =
     process.env.NODE_ENV === 'development' || (await getIsFirstRound());
 
-  // apply migrations
-  await applyMigrations();
+  if (!ENV.HASURA_SKIP_MIGRATIONS) {
+    // apply migrations
+    await applyMigrations();
+  }
 
   if (metadataShouldBeApplied) {
     await applyMetadata();

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -23,7 +23,9 @@ export const ENV = {
   get HASURA_GRAPHQL_GRAPHQL_URL() {
     return castStringEnv('HASURA_GRAPHQL_GRAPHQL_URL', '');
   },
-
+  get HASURA_SKIP_MIGRATIONS() {
+    return castBooleanEnv('HASURA_SKIP_MIGRATIONS', false);
+  },
   // SERVER
   get AUTH_HOST() {
     return castStringEnv('AUTH_HOST', '0.0.0.0');


### PR DESCRIPTION
Rationale:
-	Dependency to nhost/postgres image. This image only exists for postgres v12, whereas some users may want to use a different version e.g. v13 (better performance, new features and security fixes), or to use more “exotic” Postgres forks such as Citus, Hyperscale or any non-alpine Postgres image. Some other may not want to install PostGIS. In addition, users should be given the choice to decide how to create necessary schemas (auth, storage) and stuff (extensions and updated_at function)
-	In some cases, e.g. when using a Kubernetes job, we don’t want to try to migrate every time a container starts, but only once.
-	The current migration mechanism requires a direct superuser connection between HBP and Postgres, meaning the database is exposed both through Hasura and HBP. Some may want to reduce the attack surface in keeping only one open door to access the database – Hasura 
-	Some users would want to rely only on the existing Hasura migrations mechanism
