### PR TITLE
fix: better error message for redirectTo

### DIFF
--- a/src/routes/signin/passwordless/email.ts
+++ b/src/routes/signin/passwordless/email.ts
@@ -32,7 +32,7 @@ export const signInPasswordlessEmailHandler = async (
   // check if redirectTo is valid
   const redirectTo = options?.redirectTo ?? ENV.AUTH_CLIENT_URL;
   if (!isValidRedirectTo({ redirectTo })) {
-    return res.boom.badRequest(`'redirectTo' is not allowed`);
+    return res.boom.badRequest(`'redirectTo' is not valid.`);
   }
 
   // check if email already exist

--- a/src/routes/signup/email-password.ts
+++ b/src/routes/signup/email-password.ts
@@ -47,7 +47,7 @@ export const signUpEmailPasswordHandler = async (
   // check if redirectTo is valid
   const redirectTo = options?.redirectTo ?? ENV.AUTH_CLIENT_URL;
   if (!isValidRedirectTo({ redirectTo })) {
-    return res.boom.badRequest(`'redirectTo' is not allowed`);
+    return res.boom.badRequest(`'redirectTo' is not valid`);
   }
 
   const locale = options?.locale ?? ENV.AUTH_LOCALE_DEFAULT;

--- a/src/routes/user/email/change.ts
+++ b/src/routes/user/email/change.ts
@@ -34,7 +34,7 @@ export const userEmailChange = async (
   // check if redirectTo is valid
   const redirectTo = options?.redirectTo ?? ENV.AUTH_CLIENT_URL;
   if (!isValidRedirectTo({ redirectTo })) {
-    return res.boom.badRequest(`'redirectTo' is not allowed`);
+    return res.boom.badRequest(`'redirectTo' is not valid`);
   }
 
   if (!req.auth?.userId) {

--- a/src/routes/user/email/send-verification-email.ts
+++ b/src/routes/user/email/send-verification-email.ts
@@ -34,7 +34,7 @@ export const userEmailSendVerificationEmailHandler = async (
   // check if redirectTo is valid
   const redirectTo = options?.redirectTo ?? ENV.AUTH_CLIENT_URL;
   if (!isValidRedirectTo({ redirectTo })) {
-    return res.boom.badRequest(`'redirectTo' is not allowed`);
+    return res.boom.badRequest(`'redirectTo' is not valid`);
   }
 
   const user = await getUserByEmail(email);

--- a/src/routes/user/password-reset.ts
+++ b/src/routes/user/password-reset.ts
@@ -32,7 +32,7 @@ export const userPasswordResetHandler = async (
   // check if redirectTo is valid
   const redirectTo = options?.redirectTo ?? ENV.AUTH_CLIENT_URL;
   if (!isValidRedirectTo({ redirectTo })) {
-    return res.boom.badRequest(`'redirectTo' is not allowed`);
+    return res.boom.badRequest(`'redirectTo' is not valid`);
   }
 
   const user = await getUserByEmail(email);

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -38,14 +38,14 @@ export const isValidEmail = async ({
   // check if email is blocked
   if (ENV.AUTH_ACCESS_CONTROL_BLOCKED_EMAIL_DOMAINS.includes(emailDomain)) {
     if (res) {
-      res.boom.forbidden('Email domain is not allowed');
+      res.boom.forbidden('Email domain is not valid');
     }
     return false;
   }
 
   if (ENV.AUTH_ACCESS_CONTROL_BLOCKED_EMAILS.includes(email)) {
     if (res) {
-      res.boom.forbidden('Email is not allowed');
+      res.boom.forbidden('Email is not valid');
     }
     return false;
   }
@@ -73,7 +73,7 @@ export const isValidEmail = async ({
   }
 
   if (res) {
-    res.boom.forbidden('Email is not allowed');
+    res.boom.forbidden('Email is not valid');
   }
   return false;
 };

--- a/src/utils/user/deanonymize-email-password.ts
+++ b/src/utils/user/deanonymize-email-password.ts
@@ -39,7 +39,7 @@ export const handleDeanonymizeUserEmailPassword = async (
   // check if redirectTo is valid
   const redirectTo = options?.redirectTo ?? ENV.AUTH_CLIENT_URL;
   if (!isValidRedirectTo({ redirectTo })) {
-    return res.boom.badRequest(`'redirectTo' is not allowed`);
+    return res.boom.badRequest(`'redirectTo' is not valid`);
   }
 
   // check email

--- a/src/utils/user/deanonymize-passwordless-email.ts
+++ b/src/utils/user/deanonymize-passwordless-email.ts
@@ -38,7 +38,7 @@ export const handleDeanonymizeUserPasswordlessEmail = async (
   // check if redirectTo is valid
   const redirectTo = options?.redirectTo ?? ENV.AUTH_CLIENT_URL;
   if (!isValidRedirectTo({ redirectTo })) {
-    return res.boom.badRequest(`'redirectTo' is not allowed`);
+    return res.boom.badRequest(`'redirectTo' is not valid`);
   }
 
   // check email

--- a/test/routes/signin/passwordless/email.test.ts
+++ b/test/routes/signin/passwordless/email.test.ts
@@ -74,7 +74,7 @@ describe('passwordless email (magic link)', () => {
       .expect(404);
   });
 
-  it('should fail to sign if email is not allowed', async () => {
+  it('should fail to sign if email is not valid', async () => {
     // set env vars
     await request.post('/change-env').send({
       AUTH_DISABLE_NEW_USERS: false,


### PR DESCRIPTION
using the word "allowed" might indicate that the parameter itself (`redirectTo`) is not allowed when in fact it's the value of the parameter that is not allowed.

