### PR TITLE
ci: do not try to publish external PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,7 @@ jobs:
           file: ./coverage/clover.xml
   publish:
     needs: test
+    if: ${{ github.event_name == 'push' || github.pull_request.head.repo.full_name == 'nhost/hasura-auth' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
GH action should not try to build and publish docker image with external PRs e.g. #51 #52 #63

