### PR TITLE
feat: simplify email templates context

### DIFF
--- a/email-templates/en/email-confirm-change/body.html
+++ b/email-templates/en/email-confirm-change/body.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h2>Confirm Email Change</h2>
-    <p>Use this link to confirm changing email:</p>
-    <p>
-      <a
-        href="${serverUrl}/verify?&ticket=${ticket}&type=emailConfirmChange&redirectTo=${redirectTo}"
-      >
-        Change email
-      </a>
-    </p>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <h2>Confirm Email Change</h2>
+  <p>Use this link to confirm changing email:</p>
+  <p>
+    <a href="${link}">
+      Change email
+    </a>
+  </p>
+</body>
+
 </html>

--- a/email-templates/en/email-verify/body.html
+++ b/email-templates/en/email-verify/body.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h2>Verify Email</h2>
-    <p>Use this link to verify your email:</p>
-    <p>
-      <a
-        href="${serverUrl}/verify?&ticket=${ticket}&type=emailVerify&redirectTo=${redirectTo}"
-      >
-        Verify Email
-      </a>
-    </p>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <h2>Verify Email</h2>
+  <p>Use this link to verify your email:</p>
+  <p>
+    <a href="${link}">
+      Verify Email
+    </a>
+  </p>
+</body>
+
 </html>

--- a/email-templates/en/password-reset/body.html
+++ b/email-templates/en/password-reset/body.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h2>Reset Password</h2>
-    <p>Use this link to reset your password:</p>
-    <p>
-      <a
-        href="${serverUrl}/verify?&ticket=${ticket}&type=passwordReset&redirectTo=${redirectTo}"
-      >
-        Reset password
-      </a>
-    </p>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <h2>Reset Password</h2>
+  <p>Use this link to reset your password:</p>
+  <p>
+    <a href="${link}">
+      Reset password
+    </a>
+  </p>
+</body>
+
 </html>

--- a/email-templates/en/signin-passwordless/body.html
+++ b/email-templates/en/signin-passwordless/body.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h2>Magic Link</h2>
-    <p>Use this link to securely sign in:</p>
-    <p>
-      <a
-        href="${serverUrl}/verify?&ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}"
-      >
-        Sign In
-      </a>
-    </p>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <h2>Magic Link</h2>
+  <p>Use this link to securely sign in:</p>
+  <p>
+    <a href="${link}">
+      Sign In
+    </a>
+  </p>
+</body>
+
 </html>

--- a/email-templates/fr/email-confirm-change/body.html
+++ b/email-templates/fr/email-confirm-change/body.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h2>Confirmer changement de courriel</h2>
-    <p>Utilisez ce lien pour confirmer le changement de courriel:</p>
-    <p>
-      <a
-        href="${serverUrl}/verify?&ticket=${ticket}&type=emailConfirmChange&redirectTo=${redirectTo}"
-      >
-        Changer courriel
-      </a>
-    </p>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <h2>Confirmer changement de courriel</h2>
+  <p>Utilisez ce lien pour confirmer le changement de courriel:</p>
+  <p>
+    <a href="${link}">
+      Changer courriel
+    </a>
+  </p>
+</body>
+
 </html>

--- a/email-templates/fr/email-verify/body.html
+++ b/email-templates/fr/email-verify/body.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h2>V&eacute;rifiez votre courriel</h2>
-    <p>Utilisez ce lien pour v&eacute;rifier votre courriel:</p>
-    <p>
-      <a
-        href="${serverUrl}/verify?&ticket=${ticket}&type=emailVerify&redirectTo=${redirectTo}"
-      >
-        V&eacute;rifier courriel
-      </a>
-    </p>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <h2>V&eacute;rifiez votre courriel</h2>
+  <p>Utilisez ce lien pour v&eacute;rifier votre courriel:</p>
+  <p>
+    <a href="${link}">
+      V&eacute;rifier courriel
+    </a>
+  </p>
+</body>
+
 </html>

--- a/email-templates/fr/password-reset/body.html
+++ b/email-templates/fr/password-reset/body.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h2>R&eacute;initializer votre mot de passe</h2>
-    <p>Utilisez ce lien pour r&eacute;initializer votre mot de passe:</p>
-    <p>
-      <a
-        href="${serverUrl}/verify?&ticket=${ticket}&type=passwordReset&redirectTo=${redirectTo}"
-      >
-        R&eacute;initializer mot de passe
-      </a>
-    </p>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <h2>R&eacute;initializer votre mot de passe</h2>
+  <p>Utilisez ce lien pour r&eacute;initializer votre mot de passe:</p>
+  <p>
+    <a href="${link}">
+      R&eacute;initializer mot de passe
+    </a>
+  </p>
+</body>
+
 </html>

--- a/email-templates/fr/signin-passwordless/body.html
+++ b/email-templates/fr/signin-passwordless/body.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <h2>Lien magique</h2>
-    <p>Utilisez ce lien pour vous connecter de fa&ccedil;on s&eacute;curitaire:</p>
-    <p>
-      <a
-        href="${serverUrl}/verify?&ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}"
-      >
-        Connexion
-      </a>
-    </p>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+  <h2>Lien magique</h2>
+  <p>Utilisez ce lien pour vous connecter de fa&ccedil;on s&eacute;curitaire:</p>
+  <p>
+    <a href="${link}">
+      Connexion
+    </a>
+  </p>
+</body>
+
 </html>

--- a/src/routes/signin/passwordless/email.ts
+++ b/src/routes/signin/passwordless/email.ts
@@ -116,6 +116,7 @@ export const signInPasswordlessEmailHandler = async (
       },
     },
     locals: {
+      link: `${ENV.AUTH_SERVER_URL}/verify?&ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`,
       displayName: user.displayName,
       email,
       ticket,

--- a/src/routes/signup/email-password.ts
+++ b/src/routes/signup/email-password.ts
@@ -135,6 +135,7 @@ export const signUpEmailPasswordHandler = async (
         },
       },
       locals: {
+        link: `${ENV.AUTH_SERVER_URL}/verify?&ticket=${ticket}&type=emailVerify&redirectTo=${redirectTo}`,
         displayName,
         email,
         ticket,

--- a/src/routes/user/email/change.ts
+++ b/src/routes/user/email/change.ts
@@ -64,6 +64,7 @@ export const userEmailChange = async (
   await emailClient.send({
     template,
     locals: {
+      link: `${ENV.AUTH_SERVER_URL}/verify?&ticket=${ticket}&type=emailConfirmChange&redirectTo=${redirectTo}`,
       displayName: user.displayName,
       ticket,
       redirectTo,

--- a/src/routes/user/email/send-verification-email.ts
+++ b/src/routes/user/email/send-verification-email.ts
@@ -80,6 +80,7 @@ export const userEmailSendVerificationEmailHandler = async (
       },
     },
     locals: {
+      link: `${ENV.AUTH_SERVER_URL}/verify?&ticket=${ticket}&type=emailVerify&redirectTo=${redirectTo}`,
       displayName: user.displayName,
       ticket,
       redirectTo,

--- a/src/routes/user/password-reset.ts
+++ b/src/routes/user/password-reset.ts
@@ -56,6 +56,7 @@ export const userPasswordResetHandler = async (
   await emailClient.send({
     template,
     locals: {
+      link: `${ENV.AUTH_SERVER_URL}/verify?&ticket=${ticket}&type=passwordReset&redirectTo=${redirectTo}`,
       ticket,
       redirectTo,
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,

--- a/src/utils/user/deanonymize-email-password.ts
+++ b/src/utils/user/deanonymize-email-password.ts
@@ -126,6 +126,7 @@ export const handleDeanonymizeUserEmailPassword = async (
         },
       },
       locals: {
+        link: `${ENV.AUTH_SERVER_URL}/verify?&ticket=${ticket}&type=emailVerify&redirectTo=${redirectTo}`,
         displayName: user.displayName,
         email,
         ticket,

--- a/src/utils/user/deanonymize-passwordless-email.ts
+++ b/src/utils/user/deanonymize-passwordless-email.ts
@@ -126,6 +126,7 @@ export const handleDeanonymizeUserPasswordlessEmail = async (
         },
       },
       locals: {
+        link: `${ENV.AUTH_SERVER_URL}/verify?&ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`,
         displayName: user.displayName,
         email,
         ticket,


### PR DESCRIPTION
Email templates can now use the `${link}` context value that represents the url the email points to
e.g. email confirmation url

close #64 