### PR TITLE
feat: error redirects

### DIFF
--- a/src/routes/verify/verify.ts
+++ b/src/routes/verify/verify.ts
@@ -1,3 +1,4 @@
+import { generateRedirectUrl } from '@/utils';
 import { gqlSdk } from '@/utils/gqlSDK';
 import { getNewRefreshToken } from '@/utils/tokens';
 import { Request, Response } from 'express';
@@ -11,18 +12,29 @@ export const verifyHandler = async (
   const type = req.query.type as string;
   const redirectTo = req.query.redirectTo as string;
 
-  if (!ticket) {
-    return res.boom.badRequest('Missing ticket');
-  }
-
-  if (!type) {
-    return res.boom.badRequest('Missing type');
-  }
-
   if (!redirectTo) {
     return res.boom.badRequest('Missing redirectTo');
   }
 
+  if (!ticket) {
+    const redirectUrl = generateRedirectUrl(redirectTo, {
+      error: 'missingVerificationTicket',
+      errorDescription: 'Missing verification ticket',
+    });
+
+    return res.redirect(redirectUrl);
+  }
+
+  if (!type) {
+    const redirectUrl = generateRedirectUrl(redirectTo, {
+      error: 'missingVerificationType',
+      errorDescription: 'Missing verification type',
+    });
+
+    return res.redirect(redirectUrl);
+  }
+
+  // get the user from the ticket
   const user = await gqlSdk
     .users({
       where: {
@@ -43,7 +55,12 @@ export const verifyHandler = async (
     .then((gqlRes) => gqlRes.users[0]);
 
   if (!user) {
-    return res.boom.unauthorized('Invalid or expired ticket');
+    const redirectUrl = generateRedirectUrl(redirectTo, {
+      error: 'invalidOrExpiredVerificationTicket',
+      errorDescription: 'Invalid or expired verification ticket',
+    });
+
+    return res.redirect(redirectUrl);
   }
 
   // user found, delete current ticket
@@ -80,13 +97,16 @@ export const verifyHandler = async (
     });
   } else if (type === 'passwordReset') {
     // noop
+    // just redirecting the user to the client (as signed-in).
   }
 
   const refreshToken = await getNewRefreshToken(user.id);
 
-  // TODO: Get redirectTo url from user that can be set from the client. if
-  // `redirectTo` is set, use that one instead of `AUTH_CLIENT_URL`
-  return res.redirect(
-    `${redirectTo}#refreshToken=${refreshToken}&type=${type}`
+  const redirectUrl = generateRedirectUrl(
+    redirectTo,
+    {},
+    `#refreshToken=${refreshToken}&type=${type}`
   );
+
+  return res.redirect(redirectUrl);
 };

--- a/src/routes/verify/verify.ts
+++ b/src/routes/verify/verify.ts
@@ -18,7 +18,7 @@ export const verifyHandler = async (
 
   if (!ticket) {
     const redirectUrl = generateRedirectUrl(redirectTo, {
-      error: 'missingVerificationTicket',
+      error: 'MissingVerificationTicket',
       errorDescription: 'Missing verification ticket',
     });
 
@@ -27,7 +27,7 @@ export const verifyHandler = async (
 
   if (!type) {
     const redirectUrl = generateRedirectUrl(redirectTo, {
-      error: 'missingVerificationType',
+      error: 'MissingVerificationType',
       errorDescription: 'Missing verification type',
     });
 
@@ -56,7 +56,7 @@ export const verifyHandler = async (
 
   if (!user) {
     const redirectUrl = generateRedirectUrl(redirectTo, {
-      error: 'invalidOrExpiredVerificationTicket',
+      error: 'InvalidOrExpiredVerificationTicket',
       errorDescription: 'Invalid or expired verification ticket',
     });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,35 @@
+const generateRedirectUrl = (
+  redirectTo: string,
+  queryParameters: { [key: string]: string },
+  hashTag?: string
+): string => {
+  let finalRedirectTo = redirectTo;
+
+  // add query paramters
+  // add first ? or & depending on of there are already query parameters
+  if (redirectTo.includes('&')) {
+    finalRedirectTo += '&';
+  } else {
+    finalRedirectTo += '?';
+  }
+
+  const nrOfKeys = Object.keys(queryParameters).length;
+
+  // add query paramters
+  for (const [i, key] of Object.keys(queryParameters).entries()) {
+    // add & if not the last key
+    if (i !== nrOfKeys - 1) {
+      finalRedirectTo += key + '=' + queryParameters[key] + '&';
+    } else {
+      finalRedirectTo += key + '=' + queryParameters[key];
+    }
+  }
+
+  // add hash tag
+  if (hashTag) {
+    finalRedirectTo += '#' + hashTag;
+  }
+
+  return finalRedirectTo;
+};
+export { generateRedirectUrl };

--- a/test/routes/user/email.test.ts
+++ b/test/routes/user/email.test.ts
@@ -84,7 +84,7 @@ describe('user email', () => {
       .get(
         `/verify?ticket=${uuidv4()}&type=emailConfirmChange&redirectTo=${redirectTo}`
       )
-      .expect(401);
+      .expect(302);
 
     // confirm change email
     await request
@@ -159,7 +159,7 @@ describe('user email', () => {
       .get(
         `/verify?ticket=${uuidv4()}&type=emailConfirmChange&redirectTo=${redirectTo}`
       )
-      .expect(401);
+      .expect(302);
 
     // confirm change email
     await request


### PR DESCRIPTION
Instead of showing the error message for the user like "Invalid or expired verification ticket" Hasura Auth will redirect the user to the client with error information as query parameters. Like this:

`https://example.com?error=invalidOrExpiredVerificationTicket&errorDescription=Invalid%20or%20expired%20verification%20ticket`

This way, the app can show a nice-looking and relevant error message for the user.