### PR TITLE
fix: check if photo item exists

### DIFF
--- a/src/routes/signin/providers/utils.ts
+++ b/src/routes/signin/providers/utils.ts
@@ -223,7 +223,7 @@ export const initProvider = <T extends Strategy>(
       id,
       email: emails?.[0].value,
       displayName: displayName,
-      avatarUrl: photos?.[0].value || getGravatarUrl(emails?.[0].value),
+      avatarUrl: photos?.[0]?.value || getGravatarUrl(emails?.[0].value),
     }),
     callbackMethod = 'GET',
     ...options


### PR DESCRIPTION
Discord sent back an empty photo array causing sign-ups to fail for users with no avatar.