### PR TITLE
Insert the role in `auth.roles` when a new role is added to the Hasura metadata

### DIFF
--- a/migrations/00005_create-roles-from-metadata.sql
+++ b/migrations/00005_create-roles-from-metadata.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION auth.update_roles_from_metadata () RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN
+INSERT INTO auth.roles(role)
+SELECT DISTINCT jsonb_array_elements_text(
+        jsonb_path_query_array(
+            new.metadata::jsonb,
+            '$.sources[*].tables[*].select_permissions[*].role'
+        ) || jsonb_path_query_array(
+            new.metadata::jsonb,
+            '$.sources[*].tables[*].insert_permissions[*].role'
+        ) || jsonb_path_query_array(
+            new.metadata::jsonb,
+            '$.sources[*].tables[*].update_permissions[*].role'
+        ) || jsonb_path_query_array(
+            new.metadata::jsonb,
+            '$.sources[*].tables[*].delete_permissions[*].role'
+        )
+    ) as role ON CONFLICT DO NOTHING;
+RETURN new;
+END;
+$$;
+CREATE OR REPLACE TRIGGER update_roles_from_metadata BEFORE
+UPDATE ON hdb_catalog.hdb_metadata FOR EACH ROW EXECUTE FUNCTION auth.update_roles_from_metadata ();


### PR DESCRIPTION
@nunopato we have to make sure the Postgresql user that Hasura Auth uses to connect is authorized to add an event trigger on the `hdb_catalog` schema.

See [this discussion](https://github.com/nhost/nhost/discussions/31)

Closes #103