### PR TITLE
fix: correct redirectTo

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -93,7 +93,7 @@ export const ENV = {
 
   // CLIENT
   get AUTH_CLIENT_URL() {
-    return castStringEnv('AUTH_CLIENT_URL', '');
+    return castStringEnv('AUTH_CLIENT_URL', '').toLocaleLowerCase();
   },
 
   // SIGN UP
@@ -154,7 +154,9 @@ export const ENV = {
   //   return castBooleanEnv('AUTH_SIGNIN_PHONE_NUMBER_VERIFIED_REQUIRED', true);
   // },
   get AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS() {
-    return castStringArrayEnv('AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS');
+    return castStringArrayEnv('AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS').map(
+      (v) => v.toLowerCase()
+    );
   },
   get AUTH_MFA_ENABLED() {
     return castBooleanEnv('AUTH_MFA_ENABLED', false);

--- a/src/validation/fields.ts
+++ b/src/validation/fields.ts
@@ -63,8 +63,16 @@ export const metadata = Joi.object().default({}).example({
 export const redirectTo = Joi.alternatives()
   .default(ENV.AUTH_CLIENT_URL)
   .try(
-    Joi.valid(...ENV.AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS),
-    Joi.string().regex(new RegExp('^' + ENV.AUTH_CLIENT_URL))
+    Joi.alternatives().try(
+      ...ENV.AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS.map((value) =>
+        Joi.string()
+          .lowercase()
+          .regex(new RegExp('^' + value))
+      )
+    ),
+    Joi.string()
+      .lowercase()
+      .regex(new RegExp('^' + ENV.AUTH_CLIENT_URL))
   )
   .example(`${ENV.AUTH_CLIENT_URL}/catch-redirection`);
 

--- a/src/validation/fields.ts
+++ b/src/validation/fields.ts
@@ -63,12 +63,10 @@ export const metadata = Joi.object().default({}).example({
 export const redirectTo = Joi.alternatives()
   .default(ENV.AUTH_CLIENT_URL)
   .try(
-    Joi.alternatives().try(
-      ...ENV.AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS.map((value) =>
-        Joi.string()
-          .lowercase()
-          .regex(new RegExp('^' + value))
-      )
+    ...ENV.AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS.map((value) =>
+      Joi.string()
+        .lowercase()
+        .regex(new RegExp('^' + value))
     ),
     Joi.string()
       .lowercase()

--- a/src/validation/fields.ts
+++ b/src/validation/fields.ts
@@ -60,10 +60,12 @@ export const metadata = Joi.object().default({}).example({
   lastName: 'Smith',
 });
 
-export const redirectTo = Joi.string()
+export const redirectTo = Joi.alternatives()
   .default(ENV.AUTH_CLIENT_URL)
-  .regex(new RegExp('^' + ENV.AUTH_CLIENT_URL))
-  .valid(...ENV.AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS)
+  .try(
+    Joi.valid(...ENV.AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS),
+    Joi.string().regex(new RegExp('^' + ENV.AUTH_CLIENT_URL))
+  )
   .example(`${ENV.AUTH_CLIENT_URL}/catch-redirection`);
 
 export const uuid = Joi.string()

--- a/src/validation/validators/request-validator.ts
+++ b/src/validation/validators/request-validator.ts
@@ -1,40 +1,31 @@
 import { RequestHandler } from 'express';
 import { ValidationError, Schema } from 'joi';
 
-import { REQUEST_VALIDATION_ERROR, sendError } from '@/errors';
+import { sendError } from '@/errors';
+import { ENV } from '@/utils';
 
-const buildError = (error: ValidationError) => {
-  const errorPayload = REQUEST_VALIDATION_ERROR;
-  errorPayload.message = error.details
-    .map((detail) => detail.message)
-    .join(', ');
-  return errorPayload;
-};
-
-export const bodyValidator: (schema: Schema) => RequestHandler =
-  (schema) => async (req, res, next) => {
+const requestValidator: (
+  payload: 'body' | 'query'
+) => (schema: Schema) => RequestHandler =
+  (payload) => (schema) => async (req, res, next) => {
     try {
-      req.body = await schema.validateAsync(req.body);
+      const options = payload === 'query' ? { convert: true } : undefined;
+      req[payload] = await schema.validateAsync(req[payload], options);
       next();
     } catch (err: any) {
-      const error = buildError(err);
+      const error: ValidationError = err;
       return sendError(res, 'invalid-request', {
-        customMessage: error.message,
-        redirectTo: err._original.redirectTo,
+        customMessage: error.details.map((detail) => detail.message).join(', '),
+        // * If redirectTo is not valid, fall back to the default client url AUTH_CLIENT_URL
+        // * Else, use the redirectTo from the original request
+        redirectTo: error.details.some((detail) =>
+          detail.path.includes('redirectTo')
+        )
+          ? ENV.AUTH_CLIENT_URL
+          : error._original.redirectTo,
       });
     }
   };
 
-export const queryValidator: (schema: Schema) => RequestHandler =
-  (schema) => async (req, res, next) => {
-    try {
-      req.query = await schema.validateAsync(req.query, { convert: true });
-      next();
-    } catch (err: any) {
-      const error = buildError(err);
-      return sendError(res, 'invalid-request', {
-        customMessage: error.message,
-        redirectTo: err._original.redirectTo,
-      });
-    }
-  };
+export const bodyValidator = requestValidator('body');
+export const queryValidator = requestValidator('query');


### PR DESCRIPTION
Allow redirection either starting with AUTH_CLIENT_URL or being strictly included in
AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS. When no redirectTo is set, falls back to AUTH_CLIENT_URL

fix #137