### PR TITLE
Fix/allow unknown query parameters

### DIFF
--- a/src/routes/signin/passwordless/email.ts
+++ b/src/routes/signin/passwordless/email.ts
@@ -9,6 +9,7 @@ import {
   getGravatarUrl,
   generateTicketExpiresAt,
   ENV,
+  createEmailRedirectionLink,
 } from '@/utils';
 import { emailClient } from '@/email';
 import { EMAIL_TYPES, PasswordLessEmailBody } from '@/types';
@@ -78,6 +79,11 @@ export const signInPasswordlessEmailHandler: RequestHandler<
   });
 
   const template = 'signin-passwordless';
+  const link = createEmailRedirectionLink(
+    EMAIL_TYPES.SIGNIN_PASSWORDLESS,
+    ticket,
+    redirectTo
+  );
   await emailClient.send({
     template,
     message: {
@@ -95,14 +101,18 @@ export const signInPasswordlessEmailHandler: RequestHandler<
           prepared: true,
           value: template,
         },
+        'x-link': {
+          prepared: true,
+          value: link,
+        },
       },
     },
     locals: {
-      link: `${ENV.AUTH_SERVER_URL}/verify?&ticket=${ticket}&type=${EMAIL_TYPES.SIGNIN_PASSWORDLESS}&redirectTo=${redirectTo}`,
+      link,
       displayName: user.displayName,
       email,
       ticket,
-      redirectTo,
+      redirectTo: encodeURIComponent(redirectTo),
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
       serverUrl: ENV.AUTH_SERVER_URL,
       clientUrl: ENV.AUTH_CLIENT_URL,

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -1,3 +1,6 @@
+import { EmailType } from '@/types';
+import { ENV } from './env';
+
 export const generateRedirectUrl = (
   redirectTo: string,
   queryParameters: { [key: string]: string },
@@ -36,3 +39,14 @@ export const generateRedirectUrl = (
 
   return finalRedirectTo;
 };
+
+export const createEmailRedirectionLink = (
+  type: EmailType,
+  ticket: string,
+  redirectTo: string
+) =>
+  `${
+    ENV.AUTH_SERVER_URL
+  }/verify?&ticket=${ticket}&type=${type}&redirectTo=${encodeURIComponent(
+    redirectTo
+  )}`;

--- a/src/validation/validators/request-validator.ts
+++ b/src/validation/validators/request-validator.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express';
-import { ValidationError, Schema } from 'joi';
+import { ValidationError, Schema, AsyncValidationOptions } from 'joi';
 
 import { sendError } from '@/errors';
 import { ENV } from '@/utils';
@@ -9,7 +9,8 @@ const requestValidator: (
 ) => (schema: Schema) => RequestHandler =
   (payload) => (schema) => async (req, res, next) => {
     try {
-      const options = payload === 'query' ? { convert: true } : undefined;
+      const options: AsyncValidationOptions =
+        payload === 'query' ? { convert: true, allowUnknown: true } : {};
       req[payload] = await schema.validateAsync(req[payload], options);
       next();
     } catch (err: any) {

--- a/test/routes/misc/redirections.test.ts
+++ b/test/routes/misc/redirections.test.ts
@@ -10,6 +10,14 @@ import {
   urlParameters,
 } from '../../utils';
 
+const params = {
+  a: 'valuea',
+  b: 'valueb',
+};
+const strParams = Object.entries(params)
+  .map(([key, value]) => `${key}=${value}`)
+  .join('&');
+
 describe('Redirections', () => {
   let client: Client;
 
@@ -38,13 +46,16 @@ describe('Redirections', () => {
     });
   });
 
-  it('should ignore additional query parameters', async () => {
+  it('should ignore external query parameters', async () => {
     const email = faker.internet.email();
 
     await request
       .post('/signin/passwordless/email')
       .send({
         email,
+        options: {
+          redirectTo: `http://localhost:3000?${strParams}`,
+        },
       })
       .expect(StatusCodes.OK);
 
@@ -69,13 +80,7 @@ describe('Redirections', () => {
   it('should include query parameters in optional redirectTo', async () => {
     const email = faker.internet.email();
     // ! Urls are case insensitive
-    const params = {
-      a: 'valuea',
-      b: 'valueb',
-    };
-    const strParams = Object.entries(params)
-      .map(([key, value]) => `${key}=${value}`)
-      .join('&');
+
     await request
       .post('/signin/passwordless/email')
       .send({

--- a/test/routes/misc/redirections.test.ts
+++ b/test/routes/misc/redirections.test.ts
@@ -1,0 +1,67 @@
+import { Client } from 'pg';
+import * as faker from 'faker';
+import { StatusCodes } from 'http-status-codes';
+import { ENV } from '../../../src/utils/env';
+import { request } from '../../server';
+import {
+  mailHogSearch,
+  deleteAllMailHogEmails,
+  expectUrlParameters,
+} from '../../utils';
+
+describe('Redirections', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    client = new Client({
+      connectionString: ENV.HASURA_GRAPHQL_DATABASE_URL,
+    });
+    await client.connect();
+    deleteAllMailHogEmails();
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  beforeEach(async () => {
+    await client.query(`DELETE FROM auth.users;`);
+    // set env vars
+    await request.post('/change-env').send({
+      AUTH_DISABLE_NEW_USERS: false,
+      AUTH_EMAIL_PASSWORDLESS_ENABLED: true,
+      AUTH_ACCESS_CONTROL_ALLOWED_EMAILS: '',
+      AUTH_ACCESS_CONTROL_ALLOWED_EMAIL_DOMAINS: '',
+      AUTH_ACCESS_CONTROL_BLOCKED_EMAILS: '',
+      AUTH_ACCESS_CONTROL_BLOCKED_EMAIL_DOMAINS: '',
+    });
+  });
+
+  it('should ignore additional query parameters', async () => {
+    const email = faker.internet.email();
+
+    await request
+      .post('/signin/passwordless/email')
+      .send({
+        email,
+      })
+      .expect(StatusCodes.OK);
+
+    // get magic link email
+    const [message] = await mailHogSearch(email);
+    expect(message).toBeTruthy();
+
+    const ticket = message.Content.Headers['X-Ticket'][0];
+    const redirectTo = message.Content.Headers['X-Redirect-To'][0];
+    const req = await request
+      .get(
+        `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}&utm_source=Email&another_unrelated_param=here-anyway`
+      )
+      .expect(StatusCodes.MOVED_TEMPORARILY);
+
+    expectUrlParameters(req).not.toIncludeAnyMembers([
+      'error',
+      'errorDescription',
+    ]);
+  });
+});

--- a/test/routes/signin/passwordless/email.test.ts
+++ b/test/routes/signin/passwordless/email.test.ts
@@ -5,7 +5,11 @@ import { StatusCodes } from 'http-status-codes';
 
 import { ENV } from '../../../../src/utils/env';
 import { request } from '../../../server';
-import { mailHogSearch, deleteAllMailHogEmails } from '../../../utils';
+import {
+  mailHogSearch,
+  deleteAllMailHogEmails,
+  expectUrlParameters,
+} from '../../../utils';
 
 describe('passwordless email (magic link)', () => {
   let client: Client;
@@ -56,11 +60,16 @@ describe('passwordless email (magic link)', () => {
     const ticket = message.Content.Headers['X-Ticket'][0];
     const redirectTo = message.Content.Headers['X-Redirect-To'][0];
 
-    await request
+    const res = await request
       .get(
         `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
       )
       .expect(StatusCodes.MOVED_TEMPORARILY);
+
+    expectUrlParameters(res).not.toIncludeAnyMembers([
+      'error',
+      'errorDescription',
+    ]);
   });
 
   it('should signin in using a different locale', async () => {

--- a/test/routes/signin/passwordless/email.test.ts
+++ b/test/routes/signin/passwordless/email.test.ts
@@ -57,13 +57,9 @@ describe('passwordless email (magic link)', () => {
 
     expect(emailTemplate).toBe('signin-passwordless');
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
-    const redirectTo = message.Content.Headers['X-Redirect-To'][0];
-
+    const link = message.Content.Headers['X-Link'][0];
     const res = await request
-      .get(
-        `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
-      )
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
     expectUrlParameters(res).not.toIncludeAnyMembers([

--- a/test/routes/signup/email-password.test.ts
+++ b/test/routes/signup/email-password.test.ts
@@ -183,14 +183,11 @@ describe('email-password', () => {
     // get ticket from email
     const [message] = await mailHogSearch(email);
     expect(message).toBeTruthy();
-    const ticket = message.Content.Headers['X-Ticket'][0];
-    const redirectTo = message.Content.Headers['X-Redirect-To'][0];
+    const link = message.Content.Headers['X-Link'][0];
 
     // use ticket to verify email
     const res = await request
-      .get(
-        `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
-      )
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
     expectUrlParameters(res).not.toIncludeAnyMembers([

--- a/test/routes/signup/email-password.test.ts
+++ b/test/routes/signup/email-password.test.ts
@@ -4,7 +4,11 @@ import { StatusCodes } from 'http-status-codes';
 
 import { ENV } from '../../../src/utils/env';
 import { request } from '../../server';
-import { mailHogSearch, deleteAllMailHogEmails } from '../../utils';
+import {
+  mailHogSearch,
+  deleteAllMailHogEmails,
+  expectUrlParameters,
+} from '../../utils';
 
 describe('email-password', () => {
   let client: Client;
@@ -183,11 +187,16 @@ describe('email-password', () => {
     const redirectTo = message.Content.Headers['X-Redirect-To'][0];
 
     // use ticket to verify email
-    await request
+    const res = await request
       .get(
         `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
       )
       .expect(StatusCodes.MOVED_TEMPORARILY);
+
+    expectUrlParameters(res).not.toIncludeAnyMembers([
+      'error',
+      'errorDescription',
+    ]);
 
     // sign in should now work
     await request

--- a/test/routes/user/deanonymize.test.ts
+++ b/test/routes/user/deanonymize.test.ts
@@ -4,7 +4,11 @@ import { StatusCodes } from 'http-status-codes';
 import { ENV } from '../../../src/utils/env';
 import { request } from '../../server';
 import { SignInResponse } from '../../../src/types';
-import { mailHogSearch, deleteAllMailHogEmails } from '../../utils';
+import {
+  mailHogSearch,
+  deleteAllMailHogEmails,
+  expectUrlParameters,
+} from '../../utils';
 
 // TODO: test options
 describe('email-password', () => {
@@ -80,12 +84,16 @@ describe('email-password', () => {
       .expect(StatusCodes.UNAUTHORIZED);
 
     // should verify email using ticket from email
-    await request
+    const res = await request
       .get(
         `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
       )
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
+    expectUrlParameters(res).not.toIncludeAnyMembers([
+      'error',
+      'errorDescription',
+    ]);
     // should be able to sign in after activated account
     await request
       .post('/signin/email-password')
@@ -140,11 +148,16 @@ describe('email-password', () => {
       .expect(StatusCodes.UNAUTHORIZED);
 
     // verify
-    await request
+    const res = await request
       .get(
         `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
       )
       .expect(StatusCodes.MOVED_TEMPORARILY);
+
+    expectUrlParameters(res).not.toIncludeAnyMembers([
+      'error',
+      'errorDescription',
+    ]);
 
     // should be able to sign in using passwordless email
     await request

--- a/test/routes/user/deanonymize.test.ts
+++ b/test/routes/user/deanonymize.test.ts
@@ -68,8 +68,7 @@ describe('email-password', () => {
 
     expect(message).toBeTruthy();
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
-    const redirectTo = message.Content.Headers['X-Redirect-To'][0];
+    const link = message.Content.Headers['X-Link'][0];
 
     // should not be abel to login before email is verified
     await request
@@ -85,9 +84,7 @@ describe('email-password', () => {
 
     // should verify email using ticket from email
     const res = await request
-      .get(
-        `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
-      )
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
     expectUrlParameters(res).not.toIncludeAnyMembers([
@@ -138,8 +135,7 @@ describe('email-password', () => {
     const [message] = await mailHogSearch(email);
     expect(message).toBeTruthy();
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
-    const redirectTo = message.Content.Headers['X-Redirect-To'][0];
+    const link = message.Content.Headers['X-Link'][0];
 
     // should not be able to reuse old refresh token
     await request
@@ -149,9 +145,7 @@ describe('email-password', () => {
 
     // verify
     const res = await request
-      .get(
-        `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
-      )
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
     expectUrlParameters(res).not.toIncludeAnyMembers([

--- a/test/routes/user/email.test.ts
+++ b/test/routes/user/email.test.ts
@@ -73,9 +73,8 @@ describe('user email', () => {
     const [message] = await mailHogSearch(newEmail);
     expect(message).toBeTruthy();
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
     const redirectTo = message.Content.Headers['X-Redirect-To'][0];
-    // expect(ticket.startsWith('emailReset:')).toBeTruthy();
+    const link = message.Content.Headers['X-Link'][0];
 
     const emailType = message.Content.Headers['X-Email-Template'][0];
     expect(emailType).toBe('email-confirm-change');
@@ -91,9 +90,7 @@ describe('user email', () => {
 
     // confirm change email
     const res2 = await request
-      .get(
-        `/verify?ticket=${ticket}&type=emailConfirmChange&redirectTo=${redirectTo}`
-      )
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
     expectUrlParameters(res2).not.toIncludeAnyMembers([
@@ -133,16 +130,14 @@ describe('user email', () => {
     const [message] = await mailHogSearch(newEmail);
     expect(message).toBeTruthy();
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
+    const link = message.Content.Headers['X-Link'][0];
     const redirectTo = message.Content.Headers['X-Redirect-To'][0];
     const emailType = message.Content.Headers['X-Email-Template'][0];
     expect(emailType).toBe('email-confirm-change');
 
     // confirm change email
     const res = await request
-      .get(
-        `/verify?ticket=${ticket}&type=emailConfirmChange&redirectTo=${redirectTo}`
-      )
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
     expectUrlParameters(res).not.toIncludeAnyMembers([
@@ -164,9 +159,9 @@ describe('user email', () => {
     const [message] = await mailHogSearch(email);
     expect(message).toBeTruthy();
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
     const redirectTo = message.Content.Headers['X-Redirect-To'][0];
     const emailType = message.Content.Headers['X-Email-Template'][0];
+    const link = message.Content.Headers['X-Link'][0];
     expect(emailType).toBe('email-verify');
 
     const res = await request
@@ -178,7 +173,7 @@ describe('user email', () => {
 
     // confirm change email
     const res2 = await request
-      .get(`/verify?ticket=${ticket}&type=verifyEmail&redirectTo=${redirectTo}`)
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
     expectUrlParameters(res2).not.toIncludeAnyMembers([
       'error',
@@ -201,12 +196,12 @@ describe('user email', () => {
     const [message] = await mailHogSearch(email);
     expect(message).toBeTruthy();
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
     const redirectTo = message.Content.Headers['X-Redirect-To'][0];
+    const link = message.Content.Headers['X-Link'][0];
     expect(redirectTo).toStrictEqual(options.redirectTo);
     // confirm change email
     const res = await request
-      .get(`/verify?ticket=${ticket}&type=verifyEmail&redirectTo=${redirectTo}`)
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
     expectUrlParameters(res).not.toIncludeAnyMembers([
       'error',

--- a/test/routes/user/password.test.ts
+++ b/test/routes/user/password.test.ts
@@ -74,14 +74,11 @@ describe('user password', () => {
     const [message] = await mailHogSearch(email);
     expect(message).toBeTruthy();
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
-    const redirectTo = message.Content.Headers['X-Redirect-To'][0];
+    const link = message.Content.Headers['X-Link'][0];
 
     // use password reset link
     await request
-      .get(
-        `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
-      )
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
     // TODO
@@ -137,14 +134,12 @@ describe('user password', () => {
     const [message] = await mailHogSearch(email);
     expect(message).toBeTruthy();
 
-    const ticket = message.Content.Headers['X-Ticket'][0];
     const redirectTo = message.Content.Headers['X-Redirect-To'][0];
+    const link = message.Content.Headers['X-Link'][0];
 
     // use password reset link
     await request
-      .get(
-        `/verify?ticket=${ticket}&type=signinPasswordless&redirectTo=${redirectTo}`
-      )
+      .get(link.replace('http://localhost:4000', ''))
       .expect(StatusCodes.MOVED_TEMPORARILY);
 
     expect(redirectTo).toStrictEqual(options.redirectTo);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -127,3 +127,21 @@ export const decodeAccessToken = (accessToken: string | null) => {
     return null;
   }
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const urlParameters = (request: any) => {
+  expect(request).toBeObject();
+  const { header } = request;
+  expect(header).toBeObject();
+  expect(header.location).toBeString();
+  const url = new URL(header.location);
+  return new URLSearchParams(url.search);
+};
+
+export const expectUrlParameters = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  request: any
+): jest.JestMatchers<string[]> => {
+  const params = urlParameters(request);
+  return expect(Array.from(params.keys()));
+};


### PR DESCRIPTION
- Allow unknown query parameters
- Include `redirectTo`'s query parameters in the email link 
- Improve tests