### PR TITLE
feat: allow any `redirectTo` when no `AUTH_CLIENT_URL` is set

### DIFF
--- a/src/routes/signin/passwordless/email.ts
+++ b/src/routes/signin/passwordless/email.ts
@@ -115,7 +115,6 @@ export const signInPasswordlessEmailHandler: RequestHandler<
       redirectTo: encodeURIComponent(redirectTo),
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
       serverUrl: ENV.AUTH_SERVER_URL,
-      clientUrl: ENV.AUTH_CLIENT_URL,
     },
   });
 

--- a/src/routes/signup/email-password.ts
+++ b/src/routes/signup/email-password.ts
@@ -122,7 +122,6 @@ export const signUpEmailPasswordHandler: RequestHandler<
         redirectTo: encodeURIComponent(redirectTo),
         locale: user.locale,
         serverUrl: ENV.AUTH_SERVER_URL,
-        clientUrl: ENV.AUTH_CLIENT_URL,
       },
     });
   }

--- a/src/routes/user/email/change.ts
+++ b/src/routes/user/email/change.ts
@@ -77,7 +77,6 @@ export const userEmailChange: RequestHandler<
       redirectTo: encodeURIComponent(redirectTo),
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
       serverUrl: ENV.AUTH_SERVER_URL,
-      clientUrl: ENV.AUTH_CLIENT_URL,
     },
     message: {
       to: newEmail,

--- a/src/routes/user/email/send-verification-email.ts
+++ b/src/routes/user/email/send-verification-email.ts
@@ -96,7 +96,6 @@ export const userEmailSendVerificationEmailHandler: RequestHandler<
       redirectTo: encodeURIComponent(redirectTo),
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
       serverUrl: ENV.AUTH_SERVER_URL,
-      clientUrl: ENV.AUTH_CLIENT_URL,
     },
   });
 

--- a/src/routes/user/password-reset.ts
+++ b/src/routes/user/password-reset.ts
@@ -67,7 +67,6 @@ export const userPasswordResetHandler: RequestHandler<
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
       displayName: user.displayName,
       serverUrl: ENV.AUTH_SERVER_URL,
-      clientUrl: ENV.AUTH_CLIENT_URL,
     },
     message: {
       to: email,

--- a/src/utils/user/deanonymize-email-password.ts
+++ b/src/utils/user/deanonymize-email-password.ts
@@ -119,7 +119,6 @@ export const handleDeanonymizeUserEmailPassword = async (
         redirectTo: encodeURIComponent(redirectTo),
         locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
         serverUrl: ENV.AUTH_SERVER_URL,
-        clientUrl: ENV.AUTH_CLIENT_URL,
       },
     });
   }

--- a/src/utils/user/deanonymize-passwordless-email.ts
+++ b/src/utils/user/deanonymize-passwordless-email.ts
@@ -123,7 +123,6 @@ export const handleDeanonymizeUserPasswordlessEmail = async (
         redirectTo: encodeURIComponent(redirectTo),
         locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
         serverUrl: ENV.AUTH_SERVER_URL,
-        clientUrl: ENV.AUTH_CLIENT_URL,
       },
     });
   }

--- a/src/validation/fields.ts
+++ b/src/validation/fields.ts
@@ -61,19 +61,22 @@ export const metadata = Joi.object().default({}).example({
   lastName: 'Smith',
 });
 
-export const redirectTo = Joi.alternatives()
-  .default(ENV.AUTH_CLIENT_URL)
-  .try(
-    ...ENV.AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS.map((value) =>
-      Joi.string()
-        .lowercase()
-        .regex(new RegExp('^' + value))
-    ),
-    Joi.string()
-      .lowercase()
-      .regex(new RegExp('^' + ENV.AUTH_CLIENT_URL))
-  )
-  .example(`${ENV.AUTH_CLIENT_URL}/catch-redirection`);
+export const redirectTo = ENV.AUTH_CLIENT_URL
+  ? Joi.alternatives()
+      .default(ENV.AUTH_CLIENT_URL)
+      .try(
+        ...ENV.AUTH_ACCESS_CONTROL_ALLOWED_REDIRECT_URLS.map((value) =>
+          Joi.string()
+            .lowercase()
+            .regex(new RegExp('^' + value))
+        ),
+        Joi.string()
+          .lowercase()
+          .regex(new RegExp('^' + ENV.AUTH_CLIENT_URL))
+      )
+      // // ? Problem? if validation fails, it will always fall back to `ENV.AUTH_CLIENT_URL` instead of raising an error.
+      .example(`${ENV.AUTH_CLIENT_URL}/catch-redirection`)
+  : Joi.string().uri();
 
 export const uuid = Joi.string()
   .regex(uuidRegex)


### PR DESCRIPTION
Up to now, `AUTH_CLIENT_URL` had to be set to support transactional emails and Oauth. Now, when not
set, such feature will work as long as the `redirectTo` option is sent over by the client to Hasura
Auth. It is usefull when one wants any client to work.

Rationale:
- users don't need to determine what their client url would be before using "basic" features such as email verification or magic links
- users can use the same backend for both their `localhost` and production frontend
- run examples on stackblitz/codepen et al. 