### PR TITLE
fix: validate phone number and transform them in the international format

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,18 +4,23 @@ module.exports = {
     '@typescript-eslint/camelcase': 'off',
     'jest/expect-expect': 'off',
     'jest/no-test-callback': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off'
+    '@typescript-eslint/explicit-function-return-type': 'off',
   },
   parser: '@typescript-eslint/parser',
-  plugins: [
-    '@typescript-eslint',
-    'jest'
-  ],
+  plugins: ['@typescript-eslint', 'jest'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier/@typescript-eslint',
     'plugin:jest/recommended',
-  ]
-}
+  ],
+  overrides: [
+    {
+      files: ['*.test.ts', '*.spec.ts'],
+      rules: {
+        '@typescript-eslint/no-non-null-assertion': 'off',
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "js-yaml": "3.13.1",
     "json-to-graphql-query": "^2.2.0",
     "jsonata": "^1.8.5",
+    "libphonenumber-js": "^1.10.6",
     "nocache": "^2.1.0",
     "node-fetch": "^2.6.1",
     "nodemailer": "6.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,7 @@ specifiers:
   js-yaml: 3.13.1
   json-to-graphql-query: ^2.2.0
   jsonata: ^1.8.5
+  libphonenumber-js: ^1.10.6
   lint-staged: 10.1.3
   nocache: ^2.1.0
   node-fetch: ^2.6.1
@@ -157,6 +158,7 @@ dependencies:
   js-yaml: 3.13.1
   json-to-graphql-query: 2.2.3
   jsonata: 1.8.6
+  libphonenumber-js: 1.10.6
   nocache: 2.1.0
   node-fetch: 2.6.7
   nodemailer: 6.4.16
@@ -8281,6 +8283,10 @@ packages:
       iconv-lite: 0.6.2
       libbase64: 1.2.1
       libqp: 1.1.0
+    dev: false
+
+  /libphonenumber-js/1.10.6:
+    resolution: {integrity: sha512-CIjT100/SmntsUjsLVs2t3ufeN4KdNXUxhD07tH153pdbaCWuAjv0jK/gPuywR3IImB/U/MQM+x9RfhMs5XZiA==}
     dev: false
 
   /libqp/1.1.0:

--- a/src/routes/signin/passwordless/sms/otp.ts
+++ b/src/routes/signin/passwordless/sms/otp.ts
@@ -4,12 +4,12 @@ import bcrypt from 'bcryptjs';
 import { ENV, getSignInResponse, gqlSdk } from '@/utils';
 import { OtpSmsBody } from '@/types';
 import { sendError } from '@/errors';
-import { Joi } from '@/validation';
+import { Joi, phoneNumber } from '@/validation';
 import { isVerifySid } from '@/utils/twilio';
 import twilio from 'twilio';
 
 export const signInOtpSchema = Joi.object({
-  phoneNumber: Joi.string().required(),
+  phoneNumber,
   otp: Joi.string().required(),
 }).meta({ className: 'SignInOtpSchema' });
 

--- a/src/routes/signin/passwordless/sms/sms.ts
+++ b/src/routes/signin/passwordless/sms/sms.ts
@@ -11,12 +11,12 @@ import {
   ENV,
 } from '@/utils';
 import { sendError } from '@/errors';
-import { Joi, registrationOptions } from '@/validation';
+import { Joi, phoneNumber, registrationOptions } from '@/validation';
 import { isVerifySid } from '@/utils/twilio';
 import { logger } from '@/logger';
 
 export const signInPasswordlessSmsSchema = Joi.object({
-  phoneNumber: Joi.string().required(),
+  phoneNumber,
   options: registrationOptions,
 }).meta({ className: 'SignInPasswordlessSmsSchema' });
 

--- a/src/validation/fields.ts
+++ b/src/validation/fields.ts
@@ -138,13 +138,9 @@ export const activeMfaType = Joi.alternatives()
 export const phoneNumber = Joi.string()
   .required()
   .custom((value: string) => {
-    // * Replace '00' by '+'
+    // * Replace '00' prefix by '+'
     if (value.startsWith('00')) {
       value = value.replace('00', '+');
-    }
-    // * Add '+' if missing
-    if (!value.startsWith('+')) {
-      value = `+${value}`;
     }
     if (isValidPhoneNumber(value)) {
       return parsePhoneNumber(value).formatInternational();

--- a/src/validation/fields.ts
+++ b/src/validation/fields.ts
@@ -1,4 +1,5 @@
 import { pwnedPassword } from 'hibp';
+import { isValidPhoneNumber, parsePhoneNumber } from 'libphonenumber-js';
 
 import { ENV } from '../utils/env';
 
@@ -133,3 +134,21 @@ export const activeMfaType = Joi.alternatives()
   .description(
     'Multi-factor authentication type. A null value deactivates MFA'
   );
+
+export const phoneNumber = Joi.string()
+  .required()
+  .custom((value: string) => {
+    // * Replace '00' by '+'
+    if (value.startsWith('00')) {
+      value = value.replace('00', '+');
+    }
+    // * Add '+' if missing
+    if (!value.startsWith('+')) {
+      value = `+${value}`;
+    }
+    if (isValidPhoneNumber(value)) {
+      return parsePhoneNumber(value).formatInternational();
+    } else {
+      throw new Error('invalid phone number');
+    }
+  }, 'valid phone number');

--- a/src/validation/fields.ts
+++ b/src/validation/fields.ts
@@ -143,7 +143,7 @@ export const phoneNumber = Joi.string()
       value = value.replace('00', '+');
     }
     if (isValidPhoneNumber(value)) {
-      return parsePhoneNumber(value).formatInternational();
+      return parsePhoneNumber(value).format('E.164');
     } else {
       throw new Error('invalid phone number');
     }

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -34,7 +34,7 @@ describe('Unit tests on field validation', () => {
     it('should transform a phone number to its international format', () => {
       const { error, value } = phoneNumber.validate('+33140506070')!;
       expect(error).toBeUndefined();
-      expect(value).toEqual('+33 1 40 50 60 70');
+      expect(value).toEqual('+33140506070');
     });
 
     it("should not accept phone numbers that don't start with '+'", () => {
@@ -51,7 +51,7 @@ describe('Unit tests on field validation', () => {
     it("should accept phone numbers starts with '00'", () => {
       const { error, value } = phoneNumber.validate('0033140506070')!;
       expect(error).toBeUndefined();
-      expect(value).toEqual('+33 1 40 50 60 70');
+      expect(value).toEqual('+33140506070');
     });
   });
 });

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -37,10 +37,15 @@ describe('Unit tests on field validation', () => {
       expect(value).toEqual('+33 1 40 50 60 70');
     });
 
-    it("should accept phone numbers that don't start with '+'", () => {
-      const { error, value } = phoneNumber.validate('33140506070')!;
-      expect(error).toBeUndefined();
-      expect(value).toEqual('+33 1 40 50 60 70');
+    it("should not accept phone numbers that don't start with '+'", () => {
+      const error = phoneNumber.validate('33140506070').error!;
+      expect(error).not.toBeUndefined();
+      const {
+        details: [{ message }],
+      } = error;
+      expect(message).toBe(
+        '"value" failed custom validation because invalid phone number'
+      );
     });
 
     it("should accept phone numbers starts with '00'", () => {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,0 +1,52 @@
+import { phoneNumber } from '@/validation';
+
+describe('Unit tests on field validation', () => {
+  describe('phone number', () => {
+    it('requires a value', () => {
+      const error = phoneNumber.validate(undefined).error!;
+      expect(error).not.toBeUndefined();
+      const {
+        details: [{ message }],
+      } = error;
+      expect(message).toBe('"value" is required');
+    });
+
+    it('should not accept an empty phone number', () => {
+      const error = phoneNumber.validate('').error!;
+      expect(error).not.toBeUndefined();
+      const {
+        details: [{ message }],
+      } = error;
+      expect(message).toBe('"value" is not allowed to be empty');
+    });
+
+    it('should not accept an invalid phone number', () => {
+      const error = phoneNumber.validate('+12345678').error!;
+      expect(error).not.toBeUndefined();
+      const {
+        details: [{ message }],
+      } = error;
+      expect(message).toBe(
+        '"value" failed custom validation because invalid phone number'
+      );
+    });
+
+    it('should transform a phone number to its international format', () => {
+      const { error, value } = phoneNumber.validate('+33140506070')!;
+      expect(error).toBeUndefined();
+      expect(value).toEqual('+33 1 40 50 60 70');
+    });
+
+    it("should accept phone numbers that don't start with '+'", () => {
+      const { error, value } = phoneNumber.validate('33140506070')!;
+      expect(error).toBeUndefined();
+      expect(value).toEqual('+33 1 40 50 60 70');
+    });
+
+    it("should accept phone numbers starts with '00'", () => {
+      const { error, value } = phoneNumber.validate('0033140506070')!;
+      expect(error).toBeUndefined();
+      expect(value).toEqual('+33 1 40 50 60 70');
+    });
+  });
+});


### PR DESCRIPTION
- validate phone number before storing them to the DB or sending them to Twilio
- use the international format to avoid duplicates 