### PR TITLE
added password reset with ticket to verify route

### DIFF
--- a/src/routes/verify/verify.ts
+++ b/src/routes/verify/verify.ts
@@ -3,14 +3,14 @@ import {
   getNewRefreshToken,
   gqlSdk,
   generateRedirectUrl,
-  getUserByEmail,
+  getUserByEmail, getSignInResponse,
 } from '@/utils';
 import { Joi, redirectTo } from '@/validation';
 import { sendError } from '@/errors';
 import { EmailType, EMAIL_TYPES } from '@/types';
 
 export const verifySchema = Joi.object({
-  redirectTo: redirectTo.required(),
+  redirectTo: redirectTo,
   ticket: Joi.string().required(),
   type: Joi.string()
     .allow(...Object.values(EMAIL_TYPES))
@@ -94,6 +94,14 @@ export const verifyHandler: RequestHandler<
   } else if (type === EMAIL_TYPES.PASSWORD_RESET) {
     // noop
     // just redirecting the user to the client (as signed-in).
+  } else if (type === EMAIL_TYPES.PASSWORD_RESET_TICKET){
+    // Return sign in details for client to handle sign in and password reset process (i.e. for native Mobile UX)
+    const signInTokens = await getSignInResponse({
+      userId: user.id,
+      checkMFA: false,
+    });
+
+    return res.send(signInTokens);
   }
 
   const refreshToken = await getNewRefreshToken(user.id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,5 +125,6 @@ export const EMAIL_TYPES = {
   CONFIRM_CHANGE: 'emailConfirmChange',
   SIGNIN_PASSWORDLESS: 'signinPasswordless',
   PASSWORD_RESET: 'passwordReset',
+  PASSWORD_RESET_TICKET: 'passwordTicketReset'
 } as const;
 export type EmailType = typeof EMAIL_TYPES[keyof typeof EMAIL_TYPES];


### PR DESCRIPTION
This hasura-auth change extends the verify.ts api to also handle direct password resets with a ticket. This will provide more manual control for developers in how to manage the UX of password resets on the client side.

Specifically, this is targetting mobile developers. As the existing password reset flow includes a redirect, which when clicked on a mobile first opens the web browser and then jumps into the app. This backend change allows the mobile developers more control to set up password reset URLs in the email template to directly open the mobile app and handle the entire password reset flow within the mobile app.

This PR will be accompanied by a PR for the nhost-js SDK to add a function to `nhost.auth.passwordTicketReset({ticket: xxx}`. As the ticket is exposed in the email templates, we can use that to create any URL the developer wants in the email templates and with this ticket, handle the entire password reset flow inside the mobile app.

Please note, I removed the Joi .required() requirements for `redirectTo`, it anyway defaults to the `CLIENT_URL` and this makes the verify.ts a bit more flexible without introducing any risk of errors (what I can see).

First PR so I ask for your patience and I look forward to hearing your thoughts! @elitan 