### PR TITLE
fix: add `email` and `newEmail`  variables to all email templates

### DIFF
--- a/src/email.ts
+++ b/src/email.ts
@@ -113,10 +113,22 @@ const readRemoteTemplate = async (
   }
 };
 
+type EmailOptions = {
+  link: string;
+  displayName: string;
+  email: string;
+  newEmail: string;
+  ticket: string;
+  redirectTo: string;
+  locale: string;
+  serverUrl: string;
+  clientUrl: string;
+};
+
 /**
  * Reusable email client.
  */
-export const emailClient = new Email({
+export const emailClient = new Email<EmailOptions>({
   transport,
   message: { from: ENV.AUTH_SMTP_SENDER },
   send: true,

--- a/src/email.ts
+++ b/src/email.ts
@@ -113,7 +113,7 @@ const readRemoteTemplate = async (
   }
 };
 
-type EmailOptions = {
+type EmailLocals = {
   link: string;
   displayName: string;
   email: string;
@@ -128,7 +128,7 @@ type EmailOptions = {
 /**
  * Reusable email client.
  */
-export const emailClient = new Email<EmailOptions>({
+export const emailClient = new Email<EmailLocals>({
   transport,
   message: { from: ENV.AUTH_SMTP_SENDER },
   send: true,

--- a/src/routes/signin/passwordless/email.ts
+++ b/src/routes/signin/passwordless/email.ts
@@ -111,6 +111,7 @@ export const signInPasswordlessEmailHandler: RequestHandler<
       link,
       displayName: user.displayName,
       email,
+      newEmail: user.newEmail,
       ticket,
       redirectTo: encodeURIComponent(redirectTo),
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,

--- a/src/routes/signup/email-password.ts
+++ b/src/routes/signup/email-password.ts
@@ -118,6 +118,7 @@ export const signUpEmailPasswordHandler: RequestHandler<
         link,
         displayName,
         email,
+        newEmail: user.newEmail,
         ticket,
         redirectTo: encodeURIComponent(redirectTo),
         locale: user.locale,

--- a/src/routes/user/email/change.ts
+++ b/src/routes/user/email/change.ts
@@ -73,6 +73,8 @@ export const userEmailChange: RequestHandler<
     locals: {
       link,
       displayName: user.displayName,
+      email: user.email,
+      newEmail,
       ticket,
       redirectTo: encodeURIComponent(redirectTo),
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,

--- a/src/routes/user/email/send-verification-email.ts
+++ b/src/routes/user/email/send-verification-email.ts
@@ -92,6 +92,8 @@ export const userEmailSendVerificationEmailHandler: RequestHandler<
     locals: {
       link,
       displayName: user.displayName,
+      email: user.email,
+      newEmail: user.newEmail,
       ticket,
       redirectTo: encodeURIComponent(redirectTo),
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,

--- a/src/routes/user/password-reset.ts
+++ b/src/routes/user/password-reset.ts
@@ -62,10 +62,12 @@ export const userPasswordResetHandler: RequestHandler<
     template,
     locals: {
       link,
+      displayName: user.displayName,
+      email,
+      newEmail: user.newEmail,
       ticket,
       redirectTo: encodeURIComponent(redirectTo),
       locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
-      displayName: user.displayName,
       serverUrl: ENV.AUTH_SERVER_URL,
       clientUrl: ENV.AUTH_CLIENT_URL,
     },

--- a/src/utils/user/deanonymize-email-password.ts
+++ b/src/utils/user/deanonymize-email-password.ts
@@ -115,6 +115,7 @@ export const handleDeanonymizeUserEmailPassword = async (
         link,
         displayName: user.displayName,
         email,
+        newEmail: user.newEmail,
         ticket,
         redirectTo: encodeURIComponent(redirectTo),
         locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,

--- a/src/utils/user/deanonymize-passwordless-email.ts
+++ b/src/utils/user/deanonymize-passwordless-email.ts
@@ -119,6 +119,7 @@ export const handleDeanonymizeUserPasswordlessEmail = async (
         link,
         displayName: user.displayName,
         email,
+        newEmail: user.newEmail,
         ticket,
         redirectTo: encodeURIComponent(redirectTo),
         locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,


### PR DESCRIPTION
Email template "locals" are now strongly typed to avoid such a problem in the future.

I'm not convinced we should add `newEmail` everywhere as it only has a meaning when the user tries to change their email.
