### PR TITLE
fix: workaround for outlook safe links

### DIFF
--- a/src/routes/verify/index.ts
+++ b/src/routes/verify/index.ts
@@ -6,6 +6,9 @@ import { queryValidator } from '@/validation';
 
 const router = Router();
 
+// Workaround for Outlook safe links. See: https://github.com/nhost/hasura-auth/issues/189
+router.head('/verify', (_, res) => res.sendStatus(200));
+
 // TODO: use VerifySchema in the jsdoc
 /**
  * GET /verify


### PR DESCRIPTION
This PR adds a workaround for Outlook safe links (see https://github.com/nhost/hasura-auth/issues/189).

Tested working.