### PR TITLE
fix: do not delete ticket, but wait for it to expire

### DIFF
--- a/src/routes/verify/verify.ts
+++ b/src/routes/verify/verify.ts
@@ -53,13 +53,8 @@ export const verifyHandler: RequestHandler<
     return sendError(res, 'invalid-ticket', { redirectTo });
   }
 
-  // user found, delete current ticket
-  await gqlSdk.updateUser({
-    id: user.id,
-    user: {
-      ticket: null,
-    },
-  });
+  // We do not delete the ticket because sometimes, anti-spam software opens the link
+  // and would made the ticket to be deleted without the user having a chance to login
 
   // different types
   if (type === EMAIL_TYPES.VERIFY) {


### PR DESCRIPTION
I have used the password less authentication quite a lot lately.
And I have came to have users with (I guess) anti-spam software, which opens the link automatically.
As Hasura Auth deletes the ticket on the first opening, the user can never authenticate with this method.

So I removed the ticket deletion part. 
I have checked that Hasura Auth checks that the token is not expired, so it doesn't seem to be a security issue.

Maybe we could reduce the expireAt to now() + 5 / 10 minutes instead ?