### PR TITLE
fix: do not actually follow redirection when redirectTo is invalid

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -149,13 +149,13 @@ export const sendError = (
     customMessage,
     redirectTo,
   }: { customMessage?: string; redirectTo?: string } = {},
-  redirect?: boolean
+  forwardRedirection?: boolean
 ) => {
   const error = ERRORS[code];
   const message = customMessage ?? error.message;
   const status = error.status;
 
-  if (redirect && redirectTo) {
+  if (forwardRedirection && redirectTo) {
     const redirectUrl = generateRedirectUrl(redirectTo, {
       error: code,
       errorDescription: message,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -148,13 +148,14 @@ export const sendError = (
   {
     customMessage,
     redirectTo,
-  }: { customMessage?: string; redirectTo?: string } = {}
+  }: { customMessage?: string; redirectTo?: string } = {},
+  redirect?: boolean
 ) => {
   const error = ERRORS[code];
   const message = customMessage ?? error.message;
   const status = error.status;
 
-  if (redirectTo) {
+  if (redirect && redirectTo) {
     const redirectUrl = generateRedirectUrl(redirectTo, {
       error: code,
       errorDescription: message,

--- a/src/routes/verify/verify.ts
+++ b/src/routes/verify/verify.ts
@@ -50,7 +50,7 @@ export const verifyHandler: RequestHandler<
     .then((gqlRes) => gqlRes.users[0]);
 
   if (!user) {
-    return sendError(res, 'invalid-ticket', { redirectTo });
+    return sendError(res, 'invalid-ticket', { redirectTo }, true);
   }
 
   // user found, delete current ticket
@@ -74,7 +74,7 @@ export const verifyHandler: RequestHandler<
     // * This check is also done when requesting a new email, but is done again here as
     // * an account with `newEmail` as an email could have been created since the email change occurred
     if (await getUserByEmail(user.newEmail)) {
-      return sendError(res, 'email-already-in-use', { redirectTo });
+      return sendError(res, 'email-already-in-use', { redirectTo }, true);
     }
     // set new email for user
     await gqlSdk.updateUser({

--- a/src/validation/validators/request-validator.ts
+++ b/src/validation/validators/request-validator.ts
@@ -15,16 +15,23 @@ const requestValidator: (
       next();
     } catch (err: any) {
       const error: ValidationError = err;
-      return sendError(res, 'invalid-request', {
-        customMessage: error.details.map((detail) => detail.message).join(', '),
-        // * If redirectTo is not valid, fall back to the default client url AUTH_CLIENT_URL
-        // * Else, use the redirectTo from the original request
-        redirectTo: error.details.some((detail) =>
-          detail.path.includes('redirectTo')
-        )
-          ? ENV.AUTH_CLIENT_URL
-          : error._original.redirectTo,
-      });
+      return sendError(
+        res,
+        'invalid-request',
+        {
+          customMessage: error.details
+            .map((detail) => detail.message)
+            .join(', '),
+          // * If redirectTo is not valid, fall back to the default client url AUTH_CLIENT_URL
+          // * Else, use the redirectTo from the original request
+          redirectTo: error.details.some((detail) =>
+            detail.path.includes('redirectTo')
+          )
+            ? ENV.AUTH_CLIENT_URL
+            : error._original.redirectTo,
+        },
+        payload === 'query'
+      );
     }
   };
 

--- a/test/routes/signup/email-password.test.ts
+++ b/test/routes/signup/email-password.test.ts
@@ -201,4 +201,28 @@ describe('email-password', () => {
       .send({ email, password })
       .expect(StatusCodes.OK);
   });
+
+  it('should return an error when asking an unauthorised redirection url', async () => {
+    const email = faker.internet.email();
+    const password = faker.internet.password();
+
+    // set env vars
+    await request.post('/change-env').send({
+      AUTH_DISABLE_NEW_USERS: false,
+      AUTH_EMAIL_SIGNIN_EMAIL_VERIFIED_REQUIRED: true,
+      AUTH_USER_DEFAULT_ALLOWED_ROLES: '',
+    });
+
+    const { body } = await request
+      .post('/signup/email-password')
+      .send({
+        email,
+        password,
+        options: { redirectTo: 'http://this-redirection-url-is-forbidden.com' },
+      })
+      .expect(StatusCodes.BAD_REQUEST);
+    expect(body.message).toEqual(
+      '"options.redirectTo" does not match any of the allowed types'
+    );
+  });
 });

--- a/test/routes/signup/email-password.test.ts
+++ b/test/routes/signup/email-password.test.ts
@@ -221,8 +221,6 @@ describe('email-password', () => {
         options: { redirectTo: 'http://this-redirection-url-is-forbidden.com' },
       })
       .expect(StatusCodes.BAD_REQUEST);
-    expect(body.message).toEqual(
-      '"options.redirectTo" does not match any of the allowed types'
-    );
+    expect(body.message).toStartWith('"options.redirectTo"');
   });
 });


### PR DESCRIPTION
(except for GET requests: /verify and social providers)

let's take this react-like code:
```jsx
const { signUpEmailPassword, needsEmailVerification } = useSignUpEmailPassword()
const handle = () => {
  signUpEmailPassword({
    email: 'bob@thebuilder.com',
    password: 'strong-password',
    options: {
      redirectTo: 'http://unauthorised-url.com'
    } 
  })
}
```
Instead of returning an http `400`, the server would actually forward the error to `AUTH_CLIENT_URL`.