### PR TITLE
fix: remove comment on the auth schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ get-version:  ## Return version.
 
 .PHONY: dev
 dev: check-port install dev-env-up  ## Start development environment.
-	bash -c "trap 'make dev-env-down' EXIT; pnpm dev"
+	bash -c "trap 'make dev-env-down' EXIT; pnpm dev:start"
 
 
 .PHONY: test

--- a/migrations/00005_table-comments.sql
+++ b/migrations/00005_table-comments.sql
@@ -1,4 +1,5 @@
-comment on schema auth is 'Schema required by Hasura Auth to work. Don''t modify its structure as Hasura Auth relies on it to function properly.';
+-- Do not add a comment on the auth schema as the postgresql user is not necessarily the owner of the schema
+-- comment on schema auth is 'Schema required by Hasura Auth to work. Don''t modify its structure as Hasura Auth relies on it to function properly.';
 comment on table auth.migrations is 'Internal table for tracking migrations. Don''t modify its structure as Hasura Auth relies on it to function properly.';
 comment on table auth.provider_requests is 'Oauth requests, inserted before redirecting to the provider''s site. Don''t modify its structure as Hasura Auth relies on it to function properly.';
 comment on table auth.providers is 'List of available Oauth providers. Don''t modify its structure as Hasura Auth relies on it to function properly.';

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -15,6 +15,25 @@ export async function applyMigrations(): Promise<void> {
   const client = new Client(dbConfig);
   try {
     await client.connect();
+    /**
+     * We modified the migration 5 to remove the comment on the auth schema
+     * as the postgres user that runs hasura-auth is not necessary the owner
+     * of the schema - and thus cannot change the comment.
+     * As the migration 5 hash changed, we need to update it with the new hash.
+     */
+    try {
+      await client.query(`UPDATE "auth"."migrations"
+        SET hash='78f76f88eff3b11ebab9be4f2469020dae017110'
+        WHERE id='5' AND hash='2b4f130ec6284768ac8285d7afb7e4e607c48e70';`);
+    } catch (e: any) {
+      const log =
+        e.message === 'relation "auth.migrations" does not exist'
+          ? logger.debug
+          : logger.warn;
+      log(
+        `Could not update the hash of the migration 5 (comment on auth schema): ${e.message}`
+      );
+    }
     await migrate({ client }, './migrations', {
       migrationTableName: 'auth.migrations',
     });


### PR DESCRIPTION
The Postgres user that runs the user should be able to run the migrations even if they are not the owner of the auth schema.