### PR TITLE
fix(hasura-actions): make possible to use APIs in hasura actions

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -973,12 +973,6 @@
                      }
                   },
                   "type" : "object"
-               },
-               "password" : {
-                  "description" : "A password of minimum 3 characters",
-                  "example" : "Str0ngPassw#ord-94|%",
-                  "minLength" : 3,
-                  "type" : "string"
                }
             },
             "required" : [
@@ -1505,6 +1499,9 @@
                "newPassword" : {
                   "example" : "Str0ngPassw#ord-94|%",
                   "type" : "string"
+               },
+               "ticket" : {
+                  "type" : "string"
                }
             },
             "required" : [
@@ -1528,6 +1525,20 @@
             "required" : [
                "providerId",
                "userId"
+            ],
+            "type" : "object"
+         },
+         "VerifyAddAuthenticatorSchema" : {
+            "additionalProperties" : false,
+            "properties" : {
+               "credential" : {
+                  "additionalProperties" : false,
+                  "properties" : {},
+                  "type" : "object"
+               }
+            },
+            "required" : [
+               "credential"
             ],
             "type" : "object"
          },
@@ -1571,7 +1582,7 @@
             "type" : "object"
          },
          "Version" : {
-            "example" : "0.9.1",
+            "example" : "0.9.3",
             "type" : "string"
          }
       },
@@ -1590,7 +1601,7 @@
       },
       "termsOfService" : "",
       "title" : "Hasura auth",
-      "version" : "0.9.1"
+      "version" : "0.9.3"
    },
    "openapi" : "3.0.0",
    "paths" : {
@@ -1847,7 +1858,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -1911,7 +1922,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2251,7 +2262,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2496,7 +2507,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2577,7 +2588,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2635,7 +2646,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2693,7 +2704,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2737,7 +2748,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2795,7 +2806,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "tapplication/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2853,7 +2864,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2908,7 +2919,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "type" : "string"
                         }
@@ -2941,6 +2952,113 @@
             "summary" : "Refresh the Oauth access tokens of a given user. You must be an admin to perform this operation.",
             "tags" : [
                "User management"
+            ]
+         }
+      },
+      "/user/webauthn/add" : {
+         "post" : {
+            "deprecated" : false,
+            "parameters" : [],
+            "responses" : {
+               "400" : {
+                  "content" : {
+                     "application/json" : {
+                        "schema" : {
+                           "$ref" : "#/components/schemas/InvalidRequestError"
+                        }
+                     }
+                  },
+                  "description" : "The payload is invalid"
+               },
+               "401" : {
+                  "content" : {
+                     "application/json" : {
+                        "schema" : {
+                           "$ref" : "#/components/schemas/UnauthorizedError"
+                        }
+                     }
+                  },
+                  "description" : "Invalid email or password, or user is not verified"
+               },
+               "404" : {
+                  "content" : {
+                     "application/json" : {
+                        "schema" : {
+                           "$ref" : "#/components/schemas/DisabledEndpointError"
+                        }
+                     }
+                  },
+                  "description" : "The feature is not activated"
+               }
+            },
+            "security" : [],
+            "summary" : "Initialize adding of a new webauthn authenticator (device, browser)",
+            "tags" : [
+               "Authentication"
+            ]
+         }
+      },
+      "/user/webauthn/verify" : {
+         "post" : {
+            "deprecated" : false,
+            "parameters" : [],
+            "requestBody" : {
+               "content" : {
+                  "application/json" : {
+                     "schema" : {
+                        "$ref" : "#/components/schemas/VerifyAddAuthenticatorSchema"
+                     }
+                  }
+               },
+               "description" : "",
+               "required" : true
+            },
+            "responses" : {
+               "200" : {
+                  "content" : {
+                     "application/json" : {
+                        "schema" : {
+                           "$ref" : "#/components/schemas/SessionPayload"
+                        }
+                     }
+                  },
+                  "description" : "Signed in successfully"
+               },
+               "400" : {
+                  "content" : {
+                     "application/json" : {
+                        "schema" : {
+                           "$ref" : "#/components/schemas/InvalidRequestError"
+                        }
+                     }
+                  },
+                  "description" : "The payload is invalid"
+               },
+               "401" : {
+                  "content" : {
+                     "application/json" : {
+                        "schema" : {
+                           "$ref" : "#/components/schemas/UnauthorizedError"
+                        }
+                     }
+                  },
+                  "description" : "Invalid email or password, or user is not verified"
+               },
+               "404" : {
+                  "content" : {
+                     "application/json" : {
+                        "schema" : {
+                           "$ref" : "#/components/schemas/DisabledEndpointError"
+                        }
+                     }
+                  },
+                  "description" : "The feature is not activated"
+               }
+            },
+            "security" : [],
+            "summary" : "Verfiy adding of a new webauth authenticator (device, browser)",
+            "tags" : [
+               "Authentication"
             ]
          }
       },
@@ -3021,7 +3139,7 @@
             "responses" : {
                "200" : {
                   "content" : {
-                     "text/plain" : {
+                     "application/json" : {
                         "schema" : {
                            "$ref" : "#/components/schemas/Version"
                         }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -18,19 +18,19 @@ router.use(nocache());
 /**
  * GET /healthz
  * @summary Check if the server is up and running
- * @return 200 - Success - text/plain
+ * @return 200 - Success - application/json
  * @tags General
  */
-router.get('/healthz', (_req, res) => res.send(ReasonPhrases.OK));
+router.get('/healthz', (_req, res) => res.json(ReasonPhrases.OK));
 
 /**
  * GET /version
  * @summary Get the current Hasura-auth version
- * @return {Version} 200 - Hasura auth version - text/plain
+ * @return {Version} 200 - Hasura auth version - application/json
  * @tags General
  */
 router.get('/version', (_req, res) =>
-  res.send(JSON.stringify({ version: 'v' + process.env.npm_package_version }))
+  res.json({ version: 'v' + process.env.npm_package_version })
 );
 
 // auth routes

--- a/src/routes/signin/index.ts
+++ b/src/routes/signin/index.ts
@@ -46,7 +46,7 @@ router.post(
  * POST /signin/passwordless/email
  * @summary Email passwordless authentication
  * @param {SignInPasswordlessEmailSchema} request.body.required
- * @return {string} 200 - Email sent successfully - text/plain
+ * @return {string} 200 - Email sent successfully - application/json
  * @return {InvalidRequestError} 400 - The payload is invalid - application/json
  * @return {DisabledUserError} 401 - User is disabled - application/json
  * @return {DisabledEndpointError} 404 - The feature is not activated - application/json
@@ -62,7 +62,7 @@ router.post(
  * POST /signin/passwordless/sms
  * @summary Send a one-time password by SMS
  * @param {SignInPasswordlessSmsSchema} request.body.required
- * @return {string} 200 - SMS sent successfully - text/plain
+ * @return {string} 200 - SMS sent successfully - application/json
  * @return {InvalidRequestError} 400 - The payload is invalid - application/json
  * @return {DisabledEndpointError} 404 - The feature is not activated - application/json
  * @tags Authentication

--- a/src/routes/signin/passwordless/email.ts
+++ b/src/routes/signin/passwordless/email.ts
@@ -120,5 +120,5 @@ export const signInPasswordlessEmailHandler: RequestHandler<
     },
   });
 
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/routes/signin/passwordless/sms/sms.ts
+++ b/src/routes/signin/passwordless/sms/sms.ts
@@ -110,5 +110,5 @@ export const signInPasswordlessSmsHandler: RequestHandler<
     return sendError(res, 'cannot-send-sms');
   }
 
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/routes/signout/index.ts
+++ b/src/routes/signout/index.ts
@@ -9,7 +9,7 @@ const router = Router();
  * POST /signout
  * @summary Sign out
  * @param {SignOutSchema} request.body.required
- * @return {string} 200 - Successfully signed out - text/plain
+ * @return {string} 200 - Successfully signed out - application/json
  * @return {InvalidRequestError} 400 - The payload is invalid - application/json
  * @return {UnauthenticatedUserError} 401 - User must be signed in to sign out from all sessions - application/json
  * @security BearerAuth

--- a/src/routes/signout/signout.ts
+++ b/src/routes/signout/signout.ts
@@ -42,5 +42,5 @@ export const signOutHandler: RequestHandler<
     });
   }
 
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/routes/token/index.ts
+++ b/src/routes/token/index.ts
@@ -23,7 +23,7 @@ router.post('/token', bodyValidator(tokenSchema), aw(tokenHandler));
  * @summary Veify JWT token
  * @description If request body is not passed the autorization header will be used to be verified
  * @param {VerifyTokenSchema} request.body.optional
- * @return {string} 200 - Valid JWT token - text/plain
+ * @return {string} 200 - Valid JWT token - application/json
  * @return {UnauthorizedError} 401 - Unauthenticated user or invalid token - application/json
  * @tags General
  */

--- a/src/routes/token/verify.ts
+++ b/src/routes/token/verify.ts
@@ -17,7 +17,7 @@ export const verifyTokenHandler: RequestHandler<
 
   try {
     await getClaims(authorization);
-    return res.send(ReasonPhrases.OK);
+    return res.json(ReasonPhrases.OK);
   } catch (e) {
     return sendError(res, 'unauthenticated-user');
   }

--- a/src/routes/user/deanonymize.ts
+++ b/src/routes/user/deanonymize.ts
@@ -39,7 +39,7 @@ export const userDeanonymizeHandler: RequestHandler<
 
   if (body.signInMethod === 'passwordless' && body.connection === 'email') {
     await handleDeanonymizeUserPasswordlessEmail(body, userId, res);
-    return res.send(ReasonPhrases.OK);
+    return res.json(ReasonPhrases.OK);
   }
 
   // if (body.signInMethod === 'passwordless' && body.connection === 'sms') {

--- a/src/routes/user/email/change.ts
+++ b/src/routes/user/email/change.ts
@@ -108,5 +108,5 @@ export const userEmailChange: RequestHandler<
     },
   });
 
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/routes/user/email/send-verification-email.ts
+++ b/src/routes/user/email/send-verification-email.ts
@@ -102,5 +102,5 @@ export const userEmailSendVerificationEmailHandler: RequestHandler<
     },
   });
 
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -44,7 +44,7 @@ router.get('/user', authenticationGate, aw(userHandler));
  * POST /user/password/reset
  * @summary Send an email asking the user to reset their password
  * @param {UserPasswordResetSchema} request.body.required
- * @return {string} 200 - The email to reset the password has been sent - text/plain
+ * @return {string} 200 - The email to reset the password has been sent - application/json
  * @return {InvalidRequestError} 400 - The payload is invalid - application/json
  * @tags User management
  */
@@ -58,7 +58,7 @@ router.post(
  * POST /user/password
  * @summary Set a new password
  * @param {UserPasswordSchema} request.body.required
- * @return {string} 200 - The password has been successfully changed - text/plain
+ * @return {string} 200 - The password has been successfully changed - tapplication/json
  * @return {InvalidRequestError} 400 - The payload is invalid - application/json
  * @return {UnauthenticatedUserError} 401 - User is not authenticated - application/json
  * @security BearerAuth
@@ -74,7 +74,7 @@ router.post(
  * POST /user/email/send-verification-email
  * @summary Send an email to verify the account
  * @param {UserEmailSendVerificationEmailSchema} request.body.required
- * @return {string} 200 - Success - text/plain
+ * @return {string} 200 - Success - application/json
  * @return {InvalidRequestError} 400 - The payload format is invalid - application/json
  * @tags User management
  */
@@ -88,7 +88,7 @@ router.post(
  * POST /user/email/change
  * @summary Change the current user's email
  * @param {UserEmailChangeSchema} request.body.required
- * @return {string} 200 - A verification email has been sent to the new email - text/plain
+ * @return {string} 200 - A verification email has been sent to the new email - application/json
  * @return {InvalidRequestError} 400 - The payload format is invalid - application/json
  * @return {UnauthenticatedUserError} 401 - User is not authenticated - application/json
  * @security BearerAuth
@@ -105,7 +105,7 @@ router.post(
  * POST /user/mfa
  * @summary Activate/deactivate Multi-factor authentication
  * @param {UserMfaSchema} request.body.required
- * @return {string} 200 - Success - text/plain
+ * @return {string} 200 - Success - application/json
  * @return {InvalidRequestError} 400 - The payload format is invalid - application/json
  * @return {UnauthenticatedUserError} 401 - User is not authenticated - application/json
  * @security BearerAuth
@@ -117,7 +117,7 @@ router.post('/user/mfa', bodyValidator(userMfaSchema), aw(userMFAHandler));
  * POST /user/deanonymize
  * @summary 'Deanonymize' an anonymous user in adding missing email or email+password, depending on the chosen authentication method. Will send a confirmation email if the server is configured to do so.
  * @param {UserDeanonymizeSchema} request.body.required
- * @return {string} 200 - Success - text/plain
+ * @return {string} 200 - Success - application/json
  * @return {InvalidRequestError} 400 - The payload format is invalid - application/json
  * @return {UnauthenticatedUserError} 401 - User is not authenticated - application/json
  * @security BearerAuth
@@ -135,7 +135,7 @@ router.post(
  * @summary Refresh the Oauth access tokens of a given user. You must be an admin to perform this operation.
  * @param {UserProviderTokensSchema} request.body.required
  * @param {string} x-hasura-admin-secret.header.required - Hasura admin secret
- * @return {string} 200 - Success - text/plain
+ * @return {string} 200 - Success - application/json
  * @return {InvalidRequestError} 400 - The payload format is invalid - application/json
  * @return {InvalidAdminSecretError} 401 - Incorrect admin secret header - application/json
  * @tags User management

--- a/src/routes/user/mfa.ts
+++ b/src/routes/user/mfa.ts
@@ -66,7 +66,7 @@ export const userMFAHandler: RequestHandler<
       },
     });
 
-    return res.send(ReasonPhrases.OK);
+    return res.json(ReasonPhrases.OK);
   }
 
   // activate MFA
@@ -93,5 +93,5 @@ export const userMFAHandler: RequestHandler<
     },
   });
 
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/routes/user/password-reset.ts
+++ b/src/routes/user/password-reset.ts
@@ -94,5 +94,5 @@ export const userPasswordResetHandler: RequestHandler<
     },
   });
 
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/routes/user/password.ts
+++ b/src/routes/user/password.ts
@@ -47,5 +47,5 @@ export const userPasswordHandler: RequestHandler<
       ticket: ticket ? null : undefined, // Hasura does not update when variable is undefined
     },
   });
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/routes/user/provider-tokens.ts
+++ b/src/routes/user/provider-tokens.ts
@@ -70,5 +70,5 @@ export const userProviderTokensHandler: RequestHandler<
 
   await rotate({ providerId, userId });
 
-  return res.send(ReasonPhrases.OK);
+  return res.json(ReasonPhrases.OK);
 };

--- a/src/utils/user/deanonymize-email-password.ts
+++ b/src/utils/user/deanonymize-email-password.ts
@@ -125,5 +125,5 @@ export const handleDeanonymizeUserEmailPassword = async (
     });
   }
 
-  res.send(ReasonPhrases.OK);
+  res.json(ReasonPhrases.OK);
 };


### PR DESCRIPTION
reference #57

It was not possible to use hasura-auth APIs as Hasura actions because many of the APIs returns reason phrases as plaintext which cannot be converted to JSON. Hasura actions is trying to parse the response to JSON and the action failed, but it is executed successfully on hasura-auth.

```json
{
  "errors": [
    {
      "extensions": {
        "internal": {
          "error": "invalid json: Error in $: Failed reading: not a valid json value at 'OK'",
          "response": {
            "status": 200,
            "body": "OK",
            "headers": [
              {
                "value": "off",
                "name": "X-DNS-Prefetch-Control"
              },
              {
                "value": "SAMEORIGIN",
                "name": "X-Frame-Options"
              },
              {
                "value": "max-age=15552000; includeSubDomains",
                "name": "Strict-Transport-Security"
              },
              {
                "value": "noopen",
                "name": "X-Download-Options"
              },
              {
                "value": "nosniff",
                "name": "X-Content-Type-Options"
              },
              {
                "value": "1; mode=block",
                "name": "X-XSS-Protection"
              },
              {
                "value": "*",
                "name": "Access-Control-Allow-Origin"
              },
              {
                "value": "no-store",
                "name": "Surrogate-Control"
              },
              {
                "value": "no-store, no-cache, must-revalidate, proxy-revalidate",
                "name": "Cache-Control"
              },
              {
                "value": "no-cache",
                "name": "Pragma"
              },
              {
                "value": "0",
                "name": "Expires"
              },
              {
                "value": "text/html; charset=utf-8",
                "name": "Content-Type"
              },
              {
                "value": "2",
                "name": "Content-Length"
              },
              {
                "value": "W/\"2-nOO9QiTIwXgNtWtBJezz8kv3SLc\"",
                "name": "ETag"
              },
              {
                "value": "Sat, 09 Jul 2022 18:38:47 GMT",
                "name": "Date"
              },
              {
                "value": "keep-alive",
                "name": "Connection"
              },
              {
                "value": "timeout=5",
                "name": "Keep-Alive"
              }
            ]
          },
          "request": {
            "body": {
              "request_query": "mutation signIn {\n  phoneSignIn(phoneSignIn: {\n    displayName: \"Asen Lekov\"\n    firstName: \"Asen\"\n    lastName: \"Lekov\"\n    location: \"Sofia, Bulgaria\"\n    about: \"\"\n    phoneNumber: \"+359123456789\"\n  })\n}",
              "session_variables": {
                "x-hasura-role": "admin"
              },
              "input": {
                "phoneSignIn": {
                  "location": "Sofia, Bulgaria",
                  "lastName": "Lekov",
                  "phoneNumber": "+359123456789",
                  "about": "",
                  "firstName": "Asen",
                  "displayName": "Asen Lekov"
                }
              },
              "action": {
                "name": "phoneSignIn"
              }
            },
            "transformed_request": {
              "query_string": "",
              "body": "{\"phoneNumber\":\"+359123456789\",\"options\":{\"metadata\":{\"location\":\"Sofia, Bulgaria\",\"lastName\":\"Lekov\",\"about\":\"\",\"firstName\":\"Asen\"},\"displayName\":\"Asen Lekov\"}}",
              "url": "http://hasura-auth:4000/signin/passwordless/sms",
              "headers": [
                [
                  "User-Agent",
                  "hasura-graphql-engine/v2.8.4"
                ],
                [
                  "Content-Type",
                  "application/json"
                ]
              ],
              "method": "POST",
              "response_timeout": "30000000"
            },
            "url": "{{HASURA_AUTH_URL}}/signin/passwordless/sms",
            "headers": []
          }
        },
        "path": "$",
        "code": "unexpected"
      },
      "message": "not a valid json response from webhook"
    }
  ]
}
```

In order to fix this all plaintext reason phrases are now returned as JSON scalars.
After applying proposed changes the response even with a simple `"OK"` is parsed successfully:

```json
{
  "data": {
    "phoneSignIn": "OK"
  }
}
```
