### PR TITLE
feat(sms): support for templates for the sms message

### DIFF
--- a/email-templates/en/signin-passwordless-sms/body.txt
+++ b/email-templates/en/signin-passwordless-sms/body.txt
@@ -1,0 +1,1 @@
+Your code is ${code}.

--- a/email-templates/fr/signin-passwordless-sms/body.txt
+++ b/email-templates/fr/signin-passwordless-sms/body.txt
@@ -1,0 +1,1 @@
+Votre code est ${code}.

--- a/src/email.ts
+++ b/src/email.ts
@@ -1,13 +1,9 @@
 // TODO this library takes more than one third of the time required by hasura-auth to load
 import Email from 'email-templates';
 import nodemailer from 'nodemailer';
-import fs from 'fs';
-import axios from 'axios';
-import urlJoin from 'url-join';
 
 import { ENV } from './utils/env';
-import path from 'path';
-import { logger } from './logger';
+import { EmailLocals, renderTemplate } from './templates';
 
 /**
  * SMTP transport.
@@ -23,108 +19,6 @@ const transport = nodemailer.createTransport({
   authMethod: ENV.AUTH_SMTP_AUTH_METHOD,
 });
 
-type TemplateEngineProps = {
-  content: string;
-  variables: {
-    [key: string]: string;
-  };
-};
-
-const templateEngine = ({ content, variables }: TemplateEngineProps) => {
-  let templatedContent = content;
-
-  for (const key in variables) {
-    const regex = new RegExp(`\\\${${key}}`, 'g');
-    templatedContent = templatedContent.replace(regex, variables[key]);
-  }
-
-  return templatedContent;
-};
-
-type EmailField = 'subject' | 'html' | 'text';
-
-const convertFieldToFileName = (field: EmailField) => {
-  if (field === 'subject') {
-    return 'subject.txt';
-  }
-
-  if (field === 'html') {
-    return 'body.html';
-  }
-
-  if (field === 'text') {
-    return 'body.txt';
-  }
-
-  return null;
-};
-
-const getFileName = (view: string, locals: Record<string, string>) => {
-  // generate path to template
-  const viewSplit = view.split('/');
-  const id = viewSplit[0];
-  const field = viewSplit[1] as EmailField;
-  const { locale } = locals;
-  const fileName = convertFieldToFileName(field);
-  return `${locale}/${id}/${fileName}`;
-};
-
-const readFile = (view: string, locals: Record<string, string>): string => {
-  const { locale } = locals;
-  const fullPath = path.join(
-    ENV.PWD,
-    'email-templates',
-    getFileName(view, locals)
-  );
-  logger.debug(`Using email template: ${fullPath}`);
-  try {
-    return fs.readFileSync(fullPath).toString();
-  } catch (error) {
-    if (locale !== ENV.AUTH_LOCALE_DEFAULT)
-      return readFile(view, { ...locals, locale: ENV.AUTH_LOCALE_DEFAULT });
-    else {
-      logger.warn(`No template found at ${fullPath}`);
-      throw Error();
-    }
-  }
-};
-
-const readRemoteTemplate = async (
-  view: string,
-  locals: Record<string, string>
-): Promise<string> => {
-  const { locale } = locals;
-  const fileName = getFileName(view, locals);
-  const url = urlJoin(ENV.AUTH_EMAIL_TEMPLATE_FETCH_URL, fileName);
-  logger.debug(`Using email template: ${url}`);
-  try {
-    const result = await axios.get(url);
-    return result.data;
-  } catch (error) {
-    if (locale !== ENV.AUTH_LOCALE_DEFAULT)
-      return readRemoteTemplate(view, {
-        ...locals,
-        locale: ENV.AUTH_LOCALE_DEFAULT,
-      });
-    else {
-      logger.warn(`No template found at ${url}`);
-      throw Error();
-    }
-  }
-};
-
-type EmailLocals = {
-  link: string;
-  displayName: string;
-  email: string;
-  newEmail: string;
-  ticket: string;
-  redirectTo: string;
-  locale: string;
-  serverUrl: string;
-  clientUrl: string;
-};
-
 /**
  * Reusable email client.
  */
@@ -132,14 +26,5 @@ export const emailClient = new Email<EmailLocals>({
   transport,
   message: { from: ENV.AUTH_SMTP_SENDER },
   send: true,
-  render: async (view, locals) => {
-    try {
-      const content = ENV.AUTH_EMAIL_TEMPLATE_FETCH_URL
-        ? await readRemoteTemplate(view, locals)
-        : readFile(view, locals);
-      return templateEngine({ content, variables: locals });
-    } catch (error) {
-      return null;
-    }
-  },
+  render: renderTemplate,
 });

--- a/src/routes/signin/passwordless/sms/sms.ts
+++ b/src/routes/signin/passwordless/sms/sms.ts
@@ -14,6 +14,7 @@ import { sendError } from '@/errors';
 import { Joi, phoneNumber, registrationOptions } from '@/validation';
 import { isVerifySid } from '@/utils/twilio';
 import { logger } from '@/logger';
+import { renderTemplate } from '@/templates';
 
 export const signInPasswordlessSmsSchema = Joi.object({
   phoneNumber,
@@ -91,8 +92,15 @@ export const signInPasswordlessSmsHandler: RequestHandler<
           to: phoneNumber,
         });
     } else {
+      const template = 'signin-passwordless-sms';
+      const message = await renderTemplate(`${template}/text`, {
+        locale: user.locale ?? ENV.AUTH_LOCALE_DEFAULT,
+        displayName: user.displayName,
+        code: otp,
+      });
+
       await twilioClient.messages.create({
-        body: `Your code is ${otp}`,
+        body: message ?? `Your code is ${otp}`,
         from: ENV.AUTH_SMS_TWILIO_MESSAGING_SERVICE_ID,
         to: phoneNumber,
       });

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,130 @@
+import axios from 'axios';
+import path from 'path';
+import fs from 'fs';
+import urlJoin from 'url-join';
+import { logger } from './logger';
+import { ENV } from './utils';
+
+type TemplateEngineProps = {
+  content: string;
+  variables: {
+    [key: string]: string;
+  };
+};
+
+const templateEngine = ({ content, variables }: TemplateEngineProps) => {
+  let templatedContent = content;
+
+  for (const key in variables) {
+    const regex = new RegExp(`\\\${${key}}`, 'g');
+    templatedContent = templatedContent.replace(regex, variables[key]);
+  }
+
+  return templatedContent;
+};
+
+type EmailField = 'subject' | 'html' | 'text';
+type SmsField = 'text';
+
+const convertFieldToFileName = (field: EmailField | SmsField) => {
+  if (field === 'subject') {
+    return 'subject.txt';
+  }
+
+  if (field === 'html') {
+    return 'body.html';
+  }
+
+  if (field === 'text') {
+    return 'body.txt';
+  }
+
+  return null;
+};
+
+const getFileName = (view: string, locals: Record<string, string>) => {
+  // generate path to template
+  const viewSplit = view.split('/');
+  const id = viewSplit[0];
+  const field = viewSplit[1] as EmailField | SmsField;
+  const { locale } = locals;
+  const fileName = convertFieldToFileName(field);
+  return `${locale}/${id}/${fileName}`;
+};
+
+const readFile = (view: string, locals: Record<string, string>): string => {
+  const { locale } = locals;
+  const fullPath = path.join(
+    ENV.PWD,
+    'email-templates',
+    getFileName(view, locals)
+  );
+  logger.debug(`Using email template: ${fullPath}`);
+  try {
+    return fs.readFileSync(fullPath).toString();
+  } catch (error) {
+    if (locale !== ENV.AUTH_LOCALE_DEFAULT)
+      return readFile(view, { ...locals, locale: ENV.AUTH_LOCALE_DEFAULT });
+    else {
+      logger.warn(`No template found at ${fullPath}`);
+      throw Error();
+    }
+  }
+};
+
+const readRemoteTemplate = async (
+  view: string,
+  locals: Record<string, string>
+): Promise<string> => {
+  const { locale } = locals;
+  const fileName = getFileName(view, locals);
+  const url = urlJoin(ENV.AUTH_EMAIL_TEMPLATE_FETCH_URL, fileName);
+  logger.debug(`Using email template: ${url}`);
+  try {
+    const result = await axios.get(url);
+    return result.data;
+  } catch (error) {
+    if (locale !== ENV.AUTH_LOCALE_DEFAULT)
+      return readRemoteTemplate(view, {
+        ...locals,
+        locale: ENV.AUTH_LOCALE_DEFAULT,
+      });
+    else {
+      logger.warn(`No template found at ${url}`);
+      throw Error();
+    }
+  }
+};
+
+type CommonLocals = {
+  displayName: string;
+  locale: string;
+};
+
+export type SmsLocals = CommonLocals & {
+  code: string;
+};
+
+export type EmailLocals = CommonLocals & {
+  link: string;
+  email: string;
+  newEmail: string;
+  ticket: string;
+  redirectTo: string;
+  serverUrl: string;
+  clientUrl: string;
+};
+
+export const renderTemplate = async (
+  view: string,
+  locals: EmailLocals | SmsLocals
+) => {
+  try {
+    const content = ENV.AUTH_EMAIL_TEMPLATE_FETCH_URL
+      ? await readRemoteTemplate(view, locals)
+      : readFile(view, locals);
+    return templateEngine({ content, variables: locals });
+  } catch (error) {
+    return null;
+  }
+};

--- a/test/routes/misc/templates.test.ts
+++ b/test/routes/misc/templates.test.ts
@@ -11,4 +11,15 @@ describe('templates', () => {
 
     expect(message).toEqual('Your code is 123456.');
   });
+
+  it('ensure that not always fallback message is used for sms template', async () => {
+    const template = 'signin-passwordless-sms';
+    const message = await renderTemplate(`${template}/text`, {
+      locale: 'fr',
+      displayName: 'John Doe',
+      code: '123456',
+    });
+
+    expect(message).toEqual('Votre code est 123456.');
+  });
 });

--- a/test/routes/misc/templates.test.ts
+++ b/test/routes/misc/templates.test.ts
@@ -1,13 +1,7 @@
 import { renderTemplate } from '@/templates';
-import { request } from '../../server';
 
 describe('templates', () => {
   it('should render proper sms template', async () => {
-    // set env vars
-    await request.post('/change-env').send({
-      APP_NAME: 'NHost App',
-    });
-
     const template = 'signin-passwordless-sms';
     const message = await renderTemplate(`${template}/text`, {
       locale: 'en',

--- a/test/routes/misc/templates.test.ts
+++ b/test/routes/misc/templates.test.ts
@@ -1,0 +1,20 @@
+import { renderTemplate } from '@/templates';
+import { request } from '../../server';
+
+describe('templates', () => {
+  it('should render proper sms template', async () => {
+    // set env vars
+    await request.post('/change-env').send({
+      APP_NAME: 'NHost App',
+    });
+
+    const template = 'signin-passwordless-sms';
+    const message = await renderTemplate(`${template}/text`, {
+      locale: 'en',
+      displayName: 'John Doe',
+      code: '123456',
+    });
+
+    expect(message).toEqual('Your code is 123456.');
+  });
+});


### PR DESCRIPTION
Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated

### Breaking changes

Avoid breaking changes and regressions. If you feel it is unavoidable, make it explicit in your PR comment so we can review it and see how to handle it.

### Tests

- please make sure your changes pass the current tests (Use the `make test` or the `make watch` command).
- if you are introducing a new feature, please write as much tests as possible.

### Documentation

Please make sure the documentation is updated accordingly, in particular:

- [Workflows](https://github.com/nhost/hasura-auth/tree/main/docs/workflows). Workflows are [Mermaid sequence diagrams](https://mermaid-js.github.io/mermaid/#/sequenceDiagram)
- [Schema](https://github.com/nhost/hasura-auth/blob/main/docs/schema.md). The schema in a [Mermaid ER diagram](https://mermaid-js.github.io/mermaid/#/entityRelationshipDiagram)
- [Environment variables](https://github.com/nhost/hasura-auth/blob/main/docs/environment-variables.md). Please adjust the [.env.example](https://github.com/nhost/hasura-auth/blob/main/.env.example) file accordingly
- OpenApi specifications. We are using inline [JSDoc annotations](https://www.npmjs.com/package/express-jsdoc-swagger)

### Conventional commits

Versioning and changelog are generated following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please do your best to follow the convention, but don't worry about it too much. We will be most likely moving away to [changesets](https://github.com/changesets/changesets) soon.

Closes #196 
