### PR TITLE
fix array custom claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,7 +284,7 @@ Will automatically generate and fetch the following GraphQL query:
 }
 ```
 
-It will then use the same expressions e.g. `profile.contributesTo.project.id` to evaluate the result with [JSONata](https://jsonata.org/), and possibly transform arrays into Hasura-readable, PostgreSQL arrays.Finally, it adds the custom claims to the JWT in the `https://hasura.io/jwt/claims` namespace:
+It will then use the same expressions e.g. `profile.contributesTo[].project.id` to evaluate the result with [JSONata](https://jsonata.org/), and possibly transform arrays into Hasura-readable, PostgreSQL arrays.Finally, it adds the custom claims to the JWT in the `https://hasura.io/jwt/claims` namespace:
 
 ```json
 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,7 @@ Each custom claim is defined by a pair of a key and a value:
 - The value is a representation of the path to look at to determine the value of the claim. For instance `[profile.organisation.id](http://profile.organisation.id)` will look for the `user.profile` Hasura relationship, and the `profile.organisation` Hasura relationship. Array values are transformed into Postgres syntax so Hasura can interpret them. See the official Hasura documentation to understand the [session variables format](https://hasura.io/docs/latest/graphql/core/auth/authorization/roles-variables.html#format-of-session-variables).
 
 ```bash
-AUTH_JWT_CUSTOM_CLAIMS={"organisation-id":"profile.organisation.id", "project-ids":"profile.contributesTo.project.id"}
+AUTH_JWT_CUSTOM_CLAIMS={"organisation-id":"profile.organisation[].id", "project-ids":"profile.contributesTo[].project.id"}
 ```
 
 Will automatically generate and fetch the following GraphQL query:

--- a/docs/recipes/custom-hasura-claims.md
+++ b/docs/recipes/custom-hasura-claims.md
@@ -10,7 +10,7 @@ Each custom claim is defined by a pair of a key and a value:
 - The value is a representation of the path to look at to determine the value of the claim. For instance `profile.organisation.id` will look for the `user.profile` Hasura relationship, and the `profile.organisation` Hasura relationship. Array values are transformed into Postgres syntax so Hasura can interpret them. See the official Hasura documentation to understand the [session variables format](https://hasura.io/docs/latest/graphql/core/auth/authorization/roles-variables.html#format-of-session-variables).
 
 ```bash
-AUTH_JWT_CUSTOM_CLAIMS={"organisation-id":"profile.organisation.id", "project-ids":"profile.contributesTo.project.id"}
+AUTH_JWT_CUSTOM_CLAIMS={"organisation-id":"profile.organisation[].id", "project-ids":"profile.contributesTo[].project.id"}
 ```
 
 Will automatically generate and fetch the following GraphQL query:

--- a/docs/recipes/custom-hasura-claims.md
+++ b/docs/recipes/custom-hasura-claims.md
@@ -32,7 +32,7 @@ Will automatically generate and fetch the following GraphQL query:
 }
 ```
 
-It will then use the same expressions e.g. `profile.contributesTo.project.id` to evaluate the result with [JSONata](https://jsonata.org/), and possibly transform arrays into Hasura-readable, PostgreSQL arrays.Finally, it adds the custom claims to the JWT in the `https://hasura.io/jwt/claims` namespace:
+It will then use the same expressions e.g. `profile.contributesTo[].project.id` to evaluate the result with [JSONata](https://jsonata.org/), and possibly transform arrays into Hasura-readable, PostgreSQL arrays.Finally, it adds the custom claims to the JWT in the `https://hasura.io/jwt/claims` namespace:
 
 ```json
 {

--- a/test/routes/misc/custom-claims.test.ts
+++ b/test/routes/misc/custom-claims.test.ts
@@ -233,7 +233,7 @@ describe('custom JWT claims', () => {
   it('should add a custom claim from a nested array relationship without element in array', async () => {
     await request.post('/change-env').send({
       AUTH_JWT_CUSTOM_CLAIMS:
-        '{"project-ids":"profile.contributesTo.project.id"}',
+        '{"project-ids":"profile.contributesTo[].project.id"}',
     });
     const userProjects: string[] = [];
     const email = faker.internet.email();


### PR DESCRIPTION
- do not add custom claim value if it is null or undefined to avoid stringified `"null"` or `"undefined"` values
- accept `[]` fields to avoid [singletons](https://github.com/nhost/hasura-auth/issues/222)
- adjust documentation and tests

@L3K0V if you want to help, [this page on the Nhost documentation](https://github.com/nhost/nhost/blob/main/docs/docs/platform/graphql/permissions.md#local-custom-permission-variables) could be completed accordingly :)