### PR TITLE
fix: 🐛 Use client hostname as RP ID

### DIFF
--- a/src/env-vars-check.ts
+++ b/src/env-vars-check.ts
@@ -197,9 +197,9 @@ if (ENV.AUTH_SMS_PROVIDER) {
 }
 
 if (ENV.AUTH_WEBAUTHN_ENABLED) {
-  if (isUnset(ENV.AUTH_SERVER_URL)) {
+  if (isUnset(ENV.AUTH_CLIENT_URL)) {
     errors.push(
-      `Env var AUTH_SERVER_URL is required when the Webauthn is enabled, but no value was provided`
+      `Env var AUTH_CLIENT_URL is required when the Webauthn is enabled, but no value was provided`
     );
   }
   if (isUnset(ENV.AUTH_WEBAUTHN_RP_NAME)) {

--- a/src/utils/webauthn.ts
+++ b/src/utils/webauthn.ts
@@ -1,4 +1,4 @@
 import { ENV } from './env';
 
 export const getWebAuthnRelyingParty = () =>
-  ENV.AUTH_SERVER_URL && new URL(ENV.AUTH_SERVER_URL).hostname;
+  ENV.AUTH_CLIENT_URL && new URL(ENV.AUTH_CLIENT_URL).hostname;


### PR DESCRIPTION
See https://w3c.github.io/webauthn/#dom-publickeycredentialcreationoptions-rp