### PR TITLE
Add clarification

### DIFF
--- a/docs/recipes/custom-hasura-claims.md
+++ b/docs/recipes/custom-hasura-claims.md
@@ -32,6 +32,36 @@ Will automatically generate and fetch the following GraphQL query:
 }
 ```
 
+Please note that the strings you pass as values in your custom claims will be evaluated starting from the user object itself, hence they need to be a valid path inside it **without** the `user` part; so, for example is your user object has the following shape:
+
+```js
+user:{
+  profile:{
+    organizations:[
+      {
+        name:"org1"
+      },
+      {
+        name:"org2
+      }
+    ]
+  }
+}
+```
+
+This will not work:
+```
+// ❌ WRONG, the path `user.profile.organisation[].id` will not work
+AUTH_JWT_CUSTOM_CLAIMS={"organisation-id":"user.profile.organisation[].id"}
+```
+
+This will
+```
+// ✅ CORRECT, the path `profile.organisation[].id` will work
+AUTH_JWT_CUSTOM_CLAIMS={"organisation-id":"profile.organisation[].id"}
+```
+
+
 It will then use the same expressions e.g. `profile.contributesTo[].project.id` to evaluate the result with [JSONata](https://jsonata.org/), and possibly transform arrays into Hasura-readable, PostgreSQL arrays.Finally, it adds the custom claims to the JWT in the `https://hasura.io/jwt/claims` namespace:
 
 ```json


### PR DESCRIPTION
Added a clarification about how to build the json object passed to `AUTH_JWT_CUSTOM_CLAIMS` environement variable

Before submitting this PR:

### Checklist

- [ ] No breaking changes
- [ ] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated

### Breaking changes

Avoid breaking changes and regressions. If you feel it is unavoidable, make it explicit in your PR comment so we can review it and see how to handle it.

### Tests

- please make sure your changes pass the current tests (Use the `make test` or the `make watch` command).
- if you are introducing a new feature, please write as much tests as possible.

### Documentation

Please make sure the documentation is updated accordingly, in particular:

- [Workflows](https://github.com/nhost/hasura-auth/tree/main/docs/workflows). Workflows are [Mermaid sequence diagrams](https://mermaid-js.github.io/mermaid/#/sequenceDiagram)
- [Schema](https://github.com/nhost/hasura-auth/blob/main/docs/schema.md). The schema in a [Mermaid ER diagram](https://mermaid-js.github.io/mermaid/#/entityRelationshipDiagram)
- [Environment variables](https://github.com/nhost/hasura-auth/blob/main/docs/environment-variables.md). Please adjust the [.env.example](https://github.com/nhost/hasura-auth/blob/main/.env.example) file accordingly
- OpenApi specifications. We are using inline [JSDoc annotations](https://www.npmjs.com/package/express-jsdoc-swagger)

### Conventional commits

Versioning and changelog are generated following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please do your best to follow the convention, but don't worry about it too much. We will be most likely moving away to [changesets](https://github.com/changesets/changesets) soon.
