### PR TITLE
fix: use the metadata column in custom claims

### DIFF
--- a/src/utils/jwt/custom-claims.ts
+++ b/src/utils/jwt/custom-claims.ts
@@ -60,6 +60,11 @@ const createCustomFieldQuery = (jwtFields: Record<string, string>): string => {
     }
   });
 
+  // * Do not try to expand the `metadata` column as we know it is a JSON column
+  // * See: https://github.com/nhost/hasura-auth/issues/204#issuecomment-1281363335
+  if (fields.metadata) {
+    fields.metadata = true;
+  }
   // * Prepare the query so it will accept userId as a variable
   const query = {
     query: {


### PR DESCRIPTION
Closes https://github.com/nhost/hasura-auth/issues/204

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated
  - [x] Update the documentation to explain the limitation on JSON columns - and the exception on the `metadata` column
  - [x] Update docs.nhost.io: https://github.com/nhost/nhost/pull/1045
