### PR TITLE
fix: 🐛 Oauth redirection

### DIFF
--- a/.changeset/serious-starfishes-provide.md
+++ b/.changeset/serious-starfishes-provide.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+Fix Oauth redirection

--- a/src/routes/oauth/index.ts
+++ b/src/routes/oauth/index.ts
@@ -80,10 +80,7 @@ export const oauthProviders = Router()
    * Determine the redirect url, and store it in the locals so it is available in next middlewares
    */
   .use(`${OAUTH_ROUTE}/:provider`, ({ query }, { locals }, next) => {
-    locals.redirectTo = redirectToRule.validate(query, {
-      convert: true,
-      allowUnknown: true,
-    }).value;
+    locals.redirectTo = redirectToRule.validate(query.redirectTo).value;
     next();
   })
 


### PR DESCRIPTION
The new Grant Oauth endpoints were not setting the redirect url correctly