### PR TITLE
fix .env.example syntax for HASURA_GRAPHQL_JWT_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:secretpgpassword@localhost:5432/
 # In Docker
 # HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:secretpgpassword@postgres:5432/postgres
 
-HASURA_GRAPHQL_JWT_SECRET='{"type":"HS256", "key":"5152fa850c02dc222631cca898ed1485821a70912a6e3649c49076912daa3b62182ba013315915d64f40cddfbb8b58eb5bd11ba225336a6af45bbae07ca873f3","issuer":"hasura-auth"}'
+HASURA_GRAPHQL_JWT_SECRET={"type":"HS256", "key":"5152fa850c02dc222631cca898ed1485821a70912a6e3649c49076912daa3b62182ba013315915d64f40cddfbb8b58eb5bd11ba225336a6af45bbae07ca873f3","issuer":"hasura-auth"}
 HASURA_GRAPHQL_ADMIN_SECRET=hello123
 HASURA_GRAPHQL_GRAPHQL_URL=http://localhost:8080/v1/graphql
 


### PR DESCRIPTION
Removes single quote around `HASURA_GRAPHQL_JWT_SECRET`'s value in .env.example allowing the stack to successfully start. 
