### PR TITLE
fix: workos query parameters

### DIFF
--- a/.changeset/red-beans-divide.md
+++ b/.changeset/red-beans-divide.md
@@ -1,0 +1,7 @@
+---
+'hasura-auth': patch
+---
+
+Allow WorkOS organization/domain/connection from the query parameters
+
+The Grant `dynamic` parameter was not correctly set. Moreover, the Oauth routes were using `express.use` instead of `express.all`. As a result. the routes defined for `${OAUTH_ROUTE}/:provider` where also matching an url like `${OAUTH_ROUTE}/:provider/callback`, although they shouldn't have.

--- a/src/routes/oauth/config.ts
+++ b/src/routes/oauth/config.ts
@@ -347,6 +347,7 @@ export const PROVIDERS_CONFIG: Record<
       profile_url: `${workosBaseUrl}/profile`,
       client_id: process.env.AUTH_PROVIDER_WORKOS_CLIENT_ID,
       client_secret: process.env.AUTH_PROVIDER_WORKOS_CLIENT_SECRET,
+      dynamic: ['custom_params'],
     },
     profile: ({ profile: { raw_attributes, id, email } }) => ({
       id,


### PR DESCRIPTION
Allow WorkOS organization/domain/connection from the query parameters

The Grant `dynamic` parameter was not correctly set. Moreover, the Oauth routes were using `express.use` instead of `express.all`. As a result. the routes defined for `${OAUTH_ROUTE}/:provider` where also matching an url like `${OAUTH_ROUTE}/:provider/callback`, although they shouldn't have.
