### PR TITLE
chore: stop sending refresh tokens in the hash part of redirection urls

### DIFF
--- a/.changeset/chilled-pugs-check.md
+++ b/.changeset/chilled-pugs-check.md
@@ -1,0 +1,14 @@
+---
+'hasura-auth': minor
+---
+
+Stop sending the refresh token in the hash part of the redirection
+
+[Since 9 months](https://github.com/nhost/hasura-auth/pull/146),
+Originally, hasura-auth was adding the refresh token to the hash part of the redirection urls, but we decided to add it to the query parameters, as the hash was not accessible in SSR pages.
+We decided to add the refresh token in both places during a transition period in order to prevent a breaking change with legacy versions of the SDK, that were looking for the refresh token in the hash.
+However, since `@nhost/nhostjs@1.1.4` (April), the SDK also finds (and removes) the refresh token in both places.
+
+Sending the refresh in the hash has a significant impact on Vue users, as the vue-router is handling routes in the hash part of the url in its own way that conflicts with the urls sent by hasura-auth.
+
+This is a breaking change for clients using previous versions of the SDK, or manually looking for the refresh token in the hash instead of the query parameter

--- a/.changeset/chilled-pugs-check.md
+++ b/.changeset/chilled-pugs-check.md
@@ -4,8 +4,7 @@
 
 Stop sending the refresh token in the hash part of the redirection
 
-[Since 9 months](https://github.com/nhost/hasura-auth/pull/146),
-Originally, hasura-auth was adding the refresh token to the hash part of the redirection urls, but we decided to add it to the query parameters, as the hash was not accessible in SSR pages.
+Originally, hasura-auth was adding the refresh token to the hash part of the redirection urls, but [we decided to add it to the query parameters](https://github.com/nhost/hasura-auth/pull/146), as the hash was not accessible in SSR pages.
 We decided to add the refresh token in both places during a transition period in order to prevent a breaking change with legacy versions of the SDK, that were looking for the refresh token in the hash.
 However, since `@nhost/nhostjs@1.1.4` (April), the SDK also finds (and removes) the refresh token in both places.
 

--- a/src/routes/verify/verify.ts
+++ b/src/routes/verify/verify.ts
@@ -97,13 +97,7 @@ export const verifyHandler: RequestHandler<
   }
 
   const refreshToken = await getNewRefreshToken(user.id);
-  // ! temparily send the refresh token in both hash and query parameter
-  // TODO at a later stage, only send as a query parameter
-  const redirectUrl = generateRedirectUrl(
-    redirectTo,
-    { refreshToken, type },
-    `refreshToken=${refreshToken}&type=${type}`
-  );
+  const redirectUrl = generateRedirectUrl(redirectTo, { refreshToken, type });
 
   return res.redirect(redirectUrl);
 };

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -3,18 +3,13 @@ import { ENV } from './env';
 
 export const generateRedirectUrl = (
   redirectTo: string,
-  queryParameters: { [key: string]: string },
-  hashTag?: string
+  queryParameters: { [key: string]: string }
 ): string => {
   const url = new URL(redirectTo);
   for (const [key, value] of Object.entries(queryParameters)) {
     url.searchParams.set(key, value);
   }
 
-  // add hash tag
-  if (hashTag) {
-    url.hash = `#${hashTag}`;
-  }
   return url.href;
 };
 


### PR DESCRIPTION
Originally, hasura-auth was adding the refresh token to the hash part of the redirection urls, but we decided to add it to the query parameters, as the hash was not accessible in SSR pages.
We decided to add the refresh token in both places during a transition period in order to prevent a breaking change with legacy versions of the SDK, that were looking for the refresh token in the hash.
However, since `@nhost/nhostjs@1.1.4` (April), the SDK also finds (and removes) the refresh token in both places.

Sending the refresh in the hash has a significant impact on Vue users, as the vue-router is handling routes in the hash part of the url in its own way that conflicts with the urls sent by hasura-auth. Once this PR is merged, we will be able to solve [this issue](https://github.com/nhost/nhost/issues/832) on the SDK side.

This is a breaking change for clients using previous versions of the SDK, or manually looking for the refresh token in the hash instead of the query parameter

Solves https://github.com/nhost/nhost/issues/832
