### PR TITLE
Set custom claims to empty array when value is null | undefined

### DIFF
--- a/.changeset/curvy-rice-sin.md
+++ b/.changeset/curvy-rice-sin.md
@@ -1,0 +1,8 @@
+---
+'hasura-auth': patch
+---
+
+A custom claim that is expected to be an array (ie. contains "[]" in its path) will be set to an empty array - instead of being undefined - when its query returns no value.
+
+This allows permissions of the form "something IN X-Hasura-myCustomClaimArray" to work as intended
+when the array is empty.

--- a/src/utils/jwt/custom-claims.ts
+++ b/src/utils/jwt/custom-claims.ts
@@ -108,7 +108,11 @@ export const generateCustomClaims = async (userId: string) => {
         // * Parse the path into a JSONata AST
         const expression = jsonata(path);
         // * Evaluate the JSONata expression from the fetched user data
-        const value = expression.evaluate(user, expression);
+        let value = expression.evaluate(user, expression);
+        // * If the claim is expected to be an array and its value is undefined, set its value to an empty array
+        if (value == undefined && path.includes('[]')) {
+          value = [];
+        }
         // * Don't add the claim if the value is null or undefined
         if (value != undefined) {
           // * Convert value into a PostgreSQL format that can be used by the Hasura permissions system

--- a/test/routes/misc/custom-claims.test.ts
+++ b/test/routes/misc/custom-claims.test.ts
@@ -259,7 +259,7 @@ describe('custom JWT claims', () => {
     const jwt = await insertUserProfile();
 
     expect(jwt['https://hasura.io/jwt/claims']['x-hasura-project-ids']).toEqual(
-      undefined
+      escapeValueToPg([])
     );
   });
 


### PR DESCRIPTION
Closes #319

### Checklist

- [ ] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [ ] Documentation is updated

### Breaking changes

Until now, custom claims containing `[]` (ie. expected to be an array) were not defined at all if the array was empty.
With this PR, such claims will now be equal to an empty array (ie. `{}`).

This is a breaking change, however, I feel like this behavior is more intuitive and probably the one expected by users when defining such claims (at least, it is my case).

Please see #319 for more details.

### Documentation

I'm not sure the documentation needs to be updated about this. If it does, please let me know and I will do it.
