### PR TITLE
fix: user roles are not properly aggregated

### DIFF
--- a/src/utils/postgres-client/utils.ts
+++ b/src/utils/postgres-client/utils.ts
@@ -137,7 +137,7 @@ export const createUserQueryWhere = (where: string) =>
             SELECT user_id, coalesce(json_agg(role), '[]') AS roles
             FROM "auth"."user_roles" r
             WHERE r.user_id = u.id
-            GROUP BY user_id, role
+            GROUP BY user_id
         ) r ON r.user_id = id WHERE ${where};`;
 
 export const createUserQueryByColumn = (column: string) =>

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -20,4 +20,5 @@ export default async (): Promise<void> => {
   } finally {
     await client.end();
   }
+  process.env['AUTH_USER_DEFAULT_ALLOWED_ROLES'] = 'me,user,editor';
 };

--- a/test/oauth/__snapshots__/transform-profile.test.ts.snap
+++ b/test/oauth/__snapshots__/transform-profile.test.ts.snap
@@ -13,6 +13,7 @@ Object {
   "roles": Array [
     "me",
     "user",
+    "editor",
   ],
 }
 `;
@@ -30,6 +31,7 @@ Object {
   "roles": Array [
     "me",
     "user",
+    "editor",
   ],
 }
 `;
@@ -47,6 +49,7 @@ Object {
   "roles": Array [
     "me",
     "user",
+    "editor",
   ],
 }
 `;

--- a/test/routes/signin/email-password.test.ts
+++ b/test/routes/signin/email-password.test.ts
@@ -44,13 +44,19 @@ describe('email-password', () => {
       .send({ email, password })
       .expect(StatusCodes.OK);
 
-    const { accessToken, accessTokenExpiresIn, refreshToken } = body.session;
+    const {
+      accessToken,
+      accessTokenExpiresIn,
+      refreshToken,
+      user: { roles },
+    } = body.session;
     const { mfa } = body;
 
     expect(await isValidAccessToken(accessToken)).toBe(true);
     expect(typeof accessTokenExpiresIn).toBe('number');
     expect(typeof refreshToken).toBe('string');
     expect(mfa).toBe(null);
+    expect(roles).toContainAllValues(['user', 'me', 'editor']);
   });
 
   it('should sign in user with metadata', async () => {

--- a/test/routes/signin/passwordless/email.test.ts
+++ b/test/routes/signin/passwordless/email.test.ts
@@ -191,12 +191,6 @@ describe('passwordless email (magic link)', () => {
   });
 
   it('should fail to sign in with incorrect allowed roles', async () => {
-    // set env vars
-    await request.post('/change-env').send({
-      AUTH_USER_DEFAULT_ROLE: 'user',
-      AUTH_USER_DEFAULT_ALLOWED_ROLES: 'user',
-    });
-
     await request
       .post('/signin/passwordless/email')
       .send({
@@ -205,6 +199,11 @@ describe('passwordless email (magic link)', () => {
           allowedRoles: ['incorrect'],
         },
       })
-      .expect(StatusCodes.BAD_REQUEST);
+      .expect(StatusCodes.BAD_REQUEST, {
+        status: 400,
+        message:
+          '"options.allowedRoles[0]" does not match any of the allowed types',
+        error: 'invalid-request',
+      });
   });
 });

--- a/test/routes/signup/email-password.test.ts
+++ b/test/routes/signup/email-password.test.ts
@@ -146,21 +146,22 @@ describe('email-password', () => {
   it('allowed roles must be subset of env var AUTH_USER_DEFAULT_ALLOWED_ROLES', async () => {
     const email = faker.internet.email();
     const password = faker.internet.password();
-
-    // set env vars
-    await request.post('/change-env').send({
-      ALLOWED_USER_ROLES: 'user,editor',
-    });
-
     await request
       .post('/signup/email-password')
       .send({
         email,
         password,
-        defaultRole: 'user',
-        allowedRoles: ['user', 'some-other-role'],
+        options: {
+          defaultRole: 'user',
+          allowedRoles: ['user', 'some-other-role'],
+        },
       })
-      .expect(StatusCodes.BAD_REQUEST);
+      .expect(StatusCodes.BAD_REQUEST, {
+        status: StatusCodes.BAD_REQUEST,
+        message:
+          '"options.allowedRoles[1]" does not match any of the allowed types',
+        error: 'invalid-request',
+      });
   });
 
   it('user must verify email before being able to sign in', async () => {
@@ -171,7 +172,6 @@ describe('email-password', () => {
     await request.post('/change-env').send({
       AUTH_DISABLE_NEW_USERS: false,
       AUTH_EMAIL_SIGNIN_EMAIL_VERIFIED_REQUIRED: true,
-      AUTH_USER_DEFAULT_ALLOWED_ROLES: '',
     });
 
     await request
@@ -201,7 +201,6 @@ describe('email-password', () => {
     await request.post('/change-env').send({
       AUTH_DISABLE_NEW_USERS: false,
       AUTH_EMAIL_SIGNIN_EMAIL_VERIFIED_REQUIRED: true,
-      AUTH_USER_DEFAULT_ALLOWED_ROLES: '',
     });
 
     const { body } = await request


### PR DESCRIPTION
Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] ~~New features have new tests
- [ ] ~~Documentation is updated

### The bug

Only one role is returned by the SQL query that fetches user information.

This was not visible from the unit tests because the default role is automatically added afterward (even if not returned by the SQL query). In the end,
tests were working because of luck. I updated a test to make sure it fails before fixing the bug.

### Tests

- Note: changing `AUTH_USER_DEFAULT_ALLOWED_ROLES` with `/change-env` has no effect as the `Joi` constraint is built only once when the application starts.
- The test 'should sign in user and return valid tokens' has been modified to check the very specific bug that is fixed by this PR.
- Other tests have been fixed and updated because they were **not** testing what they intend to test.
