### PR TITLE
fix: error missing FROM-clause entry for table "up"

### DIFF
--- a/src/utils/postgres-client/index.ts
+++ b/src/utils/postgres-client/index.ts
@@ -310,7 +310,7 @@ export const pgClient = {
   getUserByProvider: async (providerId: string, providerUserId: string) => {
     const client = await pool.connect();
     const { rows } = await client.query<{ user_id?: string; id: string }>(
-      `SELECT user_id, id FROM "auth"."user_providers" WHERE up.provider_id = $1 AND up.provider_user_id = $2;`,
+      `SELECT user_id, id FROM "auth"."user_providers" WHERE provider_id = $1 AND provider_user_id = $2;`,
       [providerId, providerUserId]
     );
     let user: SqlUser | null = null;


### PR DESCRIPTION
Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass

Fixes a bug that makes the application crash when a user signs up for the first time with (at least) github (but I think it may impacts any provider).

The error was: `missing FROM-clause entry for table "up"`.
