### PR TITLE
fix: internal error occurring when an old/invalid session cookie still exists while it shouldn't

### DIFF
--- a/.changeset/sixty-chairs-mix.md
+++ b/.changeset/sixty-chairs-mix.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+Fix internal error occurring when a session cookie exists while it shouldn't

--- a/src/routes/oauth/session-store.ts
+++ b/src/routes/oauth/session-store.ts
@@ -18,7 +18,9 @@ export class SessionStore extends Store {
   ) {
     pgClient
       .providerRequest(id)
-      .then(({ options }) => callback(null, options))
+      .then((result: { options: SessionData } | null) =>
+        callback(null, result ? result.options : null)
+      )
       .catch((err) => callback(err, null));
   }
   set(id: string, session: SessionData, callback: (err: unknown) => void) {

--- a/src/utils/postgres-client/index.ts
+++ b/src/utils/postgres-client/index.ts
@@ -49,7 +49,7 @@ export const pgClient = {
       [id]
     );
     client.release();
-    return rows[0];
+    return rows.length === 0 ? null : rows[0];
   },
 
   insertRefreshToken: async (


### PR DESCRIPTION
Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass

### Fix

For some unknown reason, sometimes, the session cookie used during the OAuth2 flow is not destroyed as it should (I could not figure out why).
When this happens, Hasura Auth fails to signin again and throws an internal error.

This fix allows to handle this case properly instead of failing.

A simple way to reproduce the bug and test this fix manually is to comment the line `res.clearCookie(SESSION_NAME);` in `src/routes/oauth/index.ts`.
