### PR TITLE
fix(pat): improve logs and replace enum type

### DIFF
--- a/.changeset/fuzzy-badgers-wink.md
+++ b/.changeset/fuzzy-badgers-wink.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+fix(pat): replace enum type with an enum table to fix issues with PAT creation

--- a/migrations/00014_alter_refresh_token_type.sql
+++ b/migrations/00014_alter_refresh_token_type.sql
@@ -1,0 +1,16 @@
+BEGIN;
+ALTER TABLE auth.refresh_tokens ALTER COLUMN type TYPE text;
+ALTER TABLE auth.refresh_tokens ALTER COLUMN type DROP DEFAULT;
+DROP TYPE refresh_token_type;
+
+CREATE TABLE auth.refresh_token_type (
+  value text PRIMARY KEY,
+  comment text
+);
+
+INSERT INTO auth.refresh_token_type (value, comment) VALUES
+  ('regular', 'Regular refresh token'),
+  ('pat', 'Personal access token');
+ALTER TABLE auth.refresh_tokens ADD CONSTRAINT refresh_tokens_type_fkey FOREIGN KEY (type) REFERENCES auth.refresh_token_type (value) ON DELETE RESTRICT ON UPDATE RESTRICT;
+ALTER TABLE auth.refresh_tokens ALTER COLUMN type SET DEFAULT 'regular';
+COMMIT;

--- a/src/gql/users.graphql
+++ b/src/gql/users.graphql
@@ -77,7 +77,7 @@ query getUsersByPAT($patHash: String!) {
         { refreshTokenHash: { _eq: $patHash } }
         { user: { disabled: { _eq: false } } }
         { expiresAt: { _gte: now } }
-        { type: { _eq: "pat" } }
+        { type: { _eq: pat } }
       ]
     }
   ) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -31,6 +31,27 @@ export const hasuraAuthMetadataPatch: MetadataPatch = {
         },
       },
       {
+        table: { name: 'refresh_token_type', schema: 'auth' },
+        is_enum: true,
+        configuration: {
+          custom_name: 'refreshTokenType',
+        },
+        array_relationships: [
+          {
+            name: 'refreshTokens',
+            using: {
+              foreign_key_constraint_on: {
+                column: 'type',
+                table: {
+                  name: 'refresh_tokens',
+                  schema: 'auth',
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
         table: { name: 'refresh_tokens', schema },
         configuration: {
           custom_name: 'authRefreshTokens',
@@ -48,12 +69,19 @@ export const hasuraAuthMetadataPatch: MetadataPatch = {
           custom_column_names: {
             refresh_token: 'refreshToken',
             refresh_token_hash: 'refreshTokenHash',
+            type: 'type',
             created_at: 'createdAt',
             expires_at: 'expiresAt',
             user_id: 'userId',
           },
         },
         object_relationships: [
+          {
+            name: 'refreshTokenType',
+            using: {
+              foreign_key_constraint_on: 'type',
+            },
+          },
           {
             name: 'user',
             using: {

--- a/src/routes/pat/pat.ts
+++ b/src/routes/pat/pat.ts
@@ -1,4 +1,5 @@
 import { sendError } from '@/errors';
+import { logger } from '@/logger';
 import { getUser, gqlSdk } from '@/utils';
 import { RequestHandler } from 'express';
 import Joi from 'joi';
@@ -18,43 +19,48 @@ export const createPATHandler: RequestHandler<
     return sendError(res, 'unauthenticated-user');
   }
 
-  const { userId } = req.auth as RequestAuth;
+  try {
+    const { userId } = req.auth as RequestAuth;
 
-  const user = await getUser({ userId });
+    const user = await getUser({ userId });
 
-  if (!user) {
-    return sendError(res, 'user-not-found');
-  }
+    if (!user) {
+      return sendError(res, 'user-not-found');
+    }
 
-  const { metadata, expiresAt } = req.body;
+    const { metadata, expiresAt } = req.body;
 
-  // Note: Joi wouldn't work here because we need to compare the date to the
-  // date of the request, not the date when the schema was created
-  // 7 days
-  if (
-    new Date(expiresAt).setHours(0, 0, 0, 0) <
-    new Date().setHours(0, 0, 0, 0) + 7 * 24 * 60 * 60 * 1000
-  ) {
-    return sendError(res, 'invalid-expiry-date', {
-      customMessage: 'The expiry date must be at least 7 days from now',
+    // Note: Joi wouldn't work here because we need to compare the date to the
+    // date of the request, not the date when the schema was created
+    // 7 days
+    if (
+      new Date(expiresAt).setHours(0, 0, 0, 0) <
+      new Date().setHours(0, 0, 0, 0) + 7 * 24 * 60 * 60 * 1000
+    ) {
+      return sendError(res, 'invalid-expiry-date', {
+        customMessage: 'The expiry date must be at least 7 days from now',
+      });
+    }
+
+    const { id } = user;
+
+    const personalAccessToken = uuidv4();
+
+    await gqlSdk.insertRefreshToken({
+      refreshToken: {
+        userId: id,
+        refreshToken: personalAccessToken,
+        expiresAt: new Date(expiresAt),
+        metadata,
+        type: 'pat',
+      },
     });
+
+    return res.send({
+      personalAccessToken,
+    });
+  } catch (error) {
+    logger.error(error);
+    return sendError(res, 'internal-error');
   }
-
-  const { id } = user;
-
-  const personalAccessToken = uuidv4();
-
-  await gqlSdk.insertRefreshToken({
-    refreshToken: {
-      userId: id,
-      refreshToken: personalAccessToken,
-      expiresAt: new Date(expiresAt),
-      metadata,
-      type: 'pat',
-    },
-  });
-
-  return res.send({
-    personalAccessToken,
-  });
 };

--- a/src/routes/pat/pat.ts
+++ b/src/routes/pat/pat.ts
@@ -61,6 +61,11 @@ export const createPATHandler: RequestHandler<
     });
   } catch (error) {
     logger.error(error);
+
+    if (error instanceof Error) {
+      return sendError(res, 'internal-error', { customMessage: error.message });
+    }
+
     return sendError(res, 'internal-error');
   }
 };

--- a/src/routes/signin/pat.ts
+++ b/src/routes/signin/pat.ts
@@ -1,4 +1,5 @@
 import { sendError } from '@/errors';
+import { logger } from '@/logger';
 import { ENV, createHasuraAccessToken, getUser, getUserByPAT } from '@/utils';
 import { personalAccessToken } from '@/validation';
 import { RequestHandler } from 'express';
@@ -13,26 +14,36 @@ export const signInPATHandler: RequestHandler<
   {},
   { personalAccessToken: string }
 > = async (req, res) => {
-  const user = await getUserByPAT(req.body.personalAccessToken);
+  try {
+    const user = await getUserByPAT(req.body.personalAccessToken);
 
-  if (!user) {
-    return sendError(res, 'invalid-pat');
+    if (!user) {
+      return sendError(res, 'invalid-pat');
+    }
+
+    if (user.disabled) {
+      return sendError(res, 'disabled-user');
+    }
+
+    const accessToken = await createHasuraAccessToken(user);
+    const sessionUser = await getUser({ userId: user.id });
+
+    return res.send({
+      mfa: null,
+      session: {
+        accessToken,
+        accessTokenExpiresIn: ENV.AUTH_ACCESS_TOKEN_EXPIRES_IN,
+        refreshToken: null,
+        user: sessionUser,
+      },
+    });
+  } catch (error) {
+    logger.error(error);
+
+    if (error instanceof Error) {
+      return sendError(res, 'internal-error', { customMessage: error.message });
+    }
+
+    return sendError(res, 'internal-error');
   }
-
-  if (user.disabled) {
-    return sendError(res, 'disabled-user');
-  }
-
-  const accessToken = await createHasuraAccessToken(user);
-  const sessionUser = await getUser({ userId: user.id });
-
-  return res.send({
-    mfa: null,
-    session: {
-      accessToken,
-      accessTokenExpiresIn: ENV.AUTH_ACCESS_TOKEN_EXPIRES_IN,
-      refreshToken: null,
-      user: sessionUser,
-    },
-  });
 };

--- a/src/utils/__generated__/graphql-request.ts
+++ b/src/utils/__generated__/graphql-request.ts
@@ -18197,7 +18197,7 @@ export const GetUsersByRefreshTokenDocument = gql`
 export const GetUsersByPatDocument = gql`
     query getUsersByPAT($patHash: String!) {
   authRefreshTokens(
-    where: {_and: [{refreshTokenHash: {_eq: $patHash}}, {user: {disabled: {_eq: false}}}, {expiresAt: {_gte: now}}, {type: {_eq: "pat"}}]}
+    where: {_and: [{refreshTokenHash: {_eq: $patHash}}, {user: {disabled: {_eq: false}}}, {expiresAt: {_gte: now}}, {type: {_eq: pat}}]}
   ) {
     refreshToken
     user {


### PR DESCRIPTION
For some reason, projects using the latest Hasura Auth image couldn't create personal access tokens properly because Hasura complained about the `CREATE TYPE ... AS ENUM ...` statement we had in the migration scripts.

This PR changes that to an actual enum table that would be tracked by Hasura.