### PR TITLE
Apply migrations before waiting for Hasura.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -19,10 +19,10 @@ export const start = async () => {
   const { applyMigrations } = await import('./migrations');
   const { applyMetadata } = await import('./metadata');
 
-  // wait for hasura to be ready
-  await waitForHasura();
   // apply migrations and metadata
   await applyMigrations();
+  // wait for hasura to be ready
+  await waitForHasura();
   await applyMetadata();
   // }
 


### PR DESCRIPTION
**Problem:** The current docs suggest to extend the user schema by creating a new table in schema public with Hasura and link via a FK to the auth.user schema ([See Docs](https://github.com/nhost/hasura-auth/blob/main/docs/recipes/extending-user-schema.md)). This does not work because Nhost and Hasura may have a circular dependency on each other if you create a new environment from scratch:

Hasura migrations depend may depend on auth.user. 
Auth Service depends on Hasura to be healthy first (i.e. having migrations applied) because the order of execution is as follows:

  await waitForHasura();
  await applyMigrations();
  await applyMetadata();
  
**Solution:** 

Just change the order of execution to: 

  await applyMigrations();
  await waitForHasura();
  await applyMetadata();
  
This works because the migrations have no dependency on Hasura at all.
It fixed our problem with this circular dependency.

Also curious how this was not noticed until now. It's basically not possible to build a new environment from scratch with existing metadata/migrations when referencing auth.user in the Hasura migrations.
 