### PR TITLE
Handle comma separated allowed roles

### DIFF
--- a/.changeset/strange-seas-whisper.md
+++ b/.changeset/strange-seas-whisper.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+Fix issue where hasura auth-crashes when adding allowed roles upon signin with provider

--- a/.changeset/strange-seas-whisper.md
+++ b/.changeset/strange-seas-whisper.md
@@ -2,4 +2,4 @@
 'hasura-auth': patch
 ---
 
-Fix issue where hasura auth-crashes when adding allowed roles upon signin with provider
+fix: don't crash when adding allowed roles upon sign-in with a provider

--- a/src/routes/oauth/utils.ts
+++ b/src/routes/oauth/utils.ts
@@ -59,6 +59,18 @@ export const transformOauthProfile = async (
 
   const emailVerified = !!normalised.emailVerified;
 
+  let allowedRoles: string[] =  ENV.AUTH_USER_DEFAULT_ALLOWED_ROLES;
+
+  if(options?.allowedRoles){
+    if(Array.isArray(options.allowedRoles)){
+      allowedRoles = options.allowedRoles;
+    }
+    else if (typeof options.allowedRoles === 'string') {
+      //if for some reason it comes as a string, split it
+      allowedRoles = (options.allowedRoles as string).split(',');
+    }
+  }
+
   return {
     passwordHash: null,
     metadata: options?.metadata || {},
@@ -66,7 +78,7 @@ export const transformOauthProfile = async (
     emailVerified,
     defaultRole: options?.defaultRole || ENV.AUTH_USER_DEFAULT_ROLE,
     roles: {
-      data: (options?.allowedRoles || ENV.AUTH_USER_DEFAULT_ALLOWED_ROLES).map(
+      data: allowedRoles.map(
         (role) => ({
           role,
         })

--- a/src/routes/oauth/utils.ts
+++ b/src/routes/oauth/utils.ts
@@ -59,13 +59,12 @@ export const transformOauthProfile = async (
 
   const emailVerified = !!normalised.emailVerified;
 
-  let allowedRoles: string[] =  ENV.AUTH_USER_DEFAULT_ALLOWED_ROLES;
+  let allowedRoles: string[] = ENV.AUTH_USER_DEFAULT_ALLOWED_ROLES;
 
-  if(options?.allowedRoles){
-    if(Array.isArray(options.allowedRoles)){
+  if (options?.allowedRoles) {
+    if (Array.isArray(options.allowedRoles)) {
       allowedRoles = options.allowedRoles;
-    }
-    else if (typeof options.allowedRoles === 'string') {
+    } else if (typeof options.allowedRoles === 'string') {
       //if for some reason it comes as a string, split it
       allowedRoles = (options.allowedRoles as string).split(',');
     }
@@ -78,11 +77,9 @@ export const transformOauthProfile = async (
     emailVerified,
     defaultRole: options?.defaultRole || ENV.AUTH_USER_DEFAULT_ROLE,
     roles: {
-      data: allowedRoles.map(
-        (role) => ({
-          role,
-        })
-      ),
+      data: allowedRoles.map((role) => ({
+        role,
+      })),
     },
     locale,
     displayName,

--- a/test/oauth/__snapshots__/transform-profile.test.ts.snap
+++ b/test/oauth/__snapshots__/transform-profile.test.ts.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OAuth helpers should handle an array of allowed roles 1`] = `
+Object {
+  "avatarUrl": "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1234567890123456&height=50&width=50&ext=1234567894&hash=Qdiofewu-OPO",
+  "defaultRole": "user",
+  "displayName": "Bob Smith",
+  "email": "bob.smith@gmail.com",
+  "emailVerified": false,
+  "locale": "en",
+  "metadata": Object {},
+  "passwordHash": null,
+  "roles": Object {
+    "data": Array [
+      Object {
+        "role": "user",
+      },
+      Object {
+        "role": "me",
+      },
+    ],
+  },
+}
+`;
+
+exports[`OAuth helpers should handle comma separated allowedRoles 1`] = `
+Object {
+  "avatarUrl": "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1234567890123456&height=50&width=50&ext=1234567894&hash=Qdiofewu-OPO",
+  "defaultRole": "user",
+  "displayName": "Bob Smith",
+  "email": "bob.smith@gmail.com",
+  "emailVerified": false,
+  "locale": "en",
+  "metadata": Object {},
+  "passwordHash": null,
+  "roles": Object {
+    "data": Array [
+      Object {
+        "role": "user",
+      },
+      Object {
+        "role": "me",
+      },
+    ],
+  },
+}
+`;
+
 exports[`OAuth helpers should transform a Facebook profile 1`] = `
 Object {
   "avatarUrl": "https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1234567890123456&height=50&width=50&ext=1234567894&hash=Qdiofewu-OPO",

--- a/test/oauth/transform-profile.test.ts
+++ b/test/oauth/transform-profile.test.ts
@@ -87,7 +87,7 @@ describe('OAuth helpers', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should handle an array of allowed roles', async() => {
+  it('should handle an array of allowed roles', async () => {
     const facebookProfile = {
       id: '1234567890123456',
       name: 'Bob Smith',
@@ -105,12 +105,12 @@ describe('OAuth helpers', () => {
       profile: facebookProfile,
     });
     const output = await transformOauthProfile(normalisedProfile, {
-      allowedRoles: ['user', 'me']
+      allowedRoles: ['user', 'me'],
     });
     expect(output).toMatchSnapshot();
-  })
+  });
 
-  it('should handle comma separated allowedRoles',  async() => {
+  it('should handle comma separated allowedRoles', async () => {
     const facebookProfile = {
       id: '1234567890123456',
       name: 'Bob Smith',
@@ -128,8 +128,8 @@ describe('OAuth helpers', () => {
       profile: facebookProfile,
     });
     const output = await transformOauthProfile(normalisedProfile, {
-      allowedRoles: 'user,me' as any
+      allowedRoles: 'user,me' as any,
     });
     expect(output).toMatchSnapshot();
-  })
+  });
 });

--- a/test/oauth/transform-profile.test.ts
+++ b/test/oauth/transform-profile.test.ts
@@ -86,4 +86,50 @@ describe('OAuth helpers', () => {
     const output = await transformOauthProfile(normalisedProfile);
     expect(output).toMatchSnapshot();
   });
+
+  it('should handle an array of allowed roles', async() => {
+    const facebookProfile = {
+      id: '1234567890123456',
+      name: 'Bob Smith',
+      email: 'bob.smith@gmail.com',
+      picture: {
+        data: {
+          height: 50,
+          is_silhouette: false,
+          url: 'https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1234567890123456&height=50&width=50&ext=1234567894&hash=Qdiofewu-OPO',
+          width: 50,
+        },
+      },
+    };
+    const normalisedProfile = await normaliseProfile('facebook', {
+      profile: facebookProfile,
+    });
+    const output = await transformOauthProfile(normalisedProfile, {
+      allowedRoles: ['user', 'me']
+    });
+    expect(output).toMatchSnapshot();
+  })
+
+  it('should handle comma separated allowedRoles',  async() => {
+    const facebookProfile = {
+      id: '1234567890123456',
+      name: 'Bob Smith',
+      email: 'bob.smith@gmail.com',
+      picture: {
+        data: {
+          height: 50,
+          is_silhouette: false,
+          url: 'https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=1234567890123456&height=50&width=50&ext=1234567894&hash=Qdiofewu-OPO',
+          width: 50,
+        },
+      },
+    };
+    const normalisedProfile = await normaliseProfile('facebook', {
+      profile: facebookProfile,
+    });
+    const output = await transformOauthProfile(normalisedProfile, {
+      allowedRoles: 'user,me' as any
+    });
+    expect(output).toMatchSnapshot();
+  })
 });


### PR DESCRIPTION
Fixes https://github.com/nhost/nhost/issues/1488

This fixes the error:
```
2023-01-09 14:06:59 | hasura-auth | ELIFECYCLE  Command failed with exit code 1.
-- | -- | --
2023-01-09 14:06:59 | hasura-auth | at async /app/dist/routes/oauth/index.js:241:31
2023-01-09 14:06:59 | hasura-auth | at processTicksAndRejections (node:internal/process/task_queues:96:5)
2023-01-09 14:06:59 | hasura-auth | at transformOauthProfile (/app/dist/routes/oauth/utils.js:40:141)
2023-01-09 14:06:59 | hasura-auth | TypeError: ((intermediate value)(intermediate value)(intermediate value) \|\| utils_1.ENV.AUTH_USER_DEFAULT_ALLOWED_ROLES).map is not a function
2023-01-09 14:06:59 | hasura-auth |  
2023-01-09 14:06:59 | hasura-auth | ^
2023-01-09 14:06:59 | hasura-auth | data: ((options === null \|\| options === void 0 ? void 0 : options.allowedRoles) \|\| utils_1.ENV.AUTH_USER_DEFAULT_ALLOWED_ROLES).map((role) => ({
2023-01-09 14:06:59 | hasura-auth | /app/dist/routes/oauth/utils.js:40
```

When `allowedRoles` is passed as an option when signing in, I noticed that it [sets the `session.options` from the query](https://github.com/nhost/hasura-auth/blob/fe87694e88a0284048d44f33eac7c2e299187070/src/routes/oauth/index.ts#LL140C15-L140C15) [then it dereferences it](https://github.com/nhost/hasura-auth/blob/fe87694e88a0284048d44f33eac7c2e299187070/src/routes/oauth/index.ts#LL162C5-L162C81) then [passes it to the `transformOauthProfile`](https://github.com/nhost/hasura-auth/blob/fe87694e88a0284048d44f33eac7c2e299187070/src/routes/oauth/index.ts#LL272C33-L272C54) which expects a `string[]`, but is actually a comma separated `string`

Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated

