### PR TITLE
chore: improve logging and bump Node.js to v18

### DIFF
--- a/.changeset/little-lions-eat.md
+++ b/.changeset/little-lions-eat.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+chore(logs): improve logging in production

--- a/.changeset/swift-roses-trade.md
+++ b/.changeset/swift-roses-trade.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': minor
+---
+
+chore(node): bump Node.js to v18

--- a/.github/actions/install-dependencies/action.yaml
+++ b/.github/actions/install-dependencies/action.yaml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2.2.4
       with:
-        version: 8.5.1
+        version: 8.6.2
         run_install: false
     - name: Get pnpm cache directory
       id: pnpm-cache-dir
@@ -19,10 +19,10 @@ runs:
           ~/.cache/Cypress
         key: ${{ runner.os }}-node-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: ${{ runner.os }}-node-
-    - name: Use Node.js 16
+    - name: Use Node.js v18
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - shell: bash
       name: Install packages
       run: pnpm install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM node:16-alpine AS builder
+FROM node:18-alpine AS builder
 WORKDIR /app
-RUN npm i -g pnpm@8.5.1
+RUN npm i -g pnpm@8.6.2
 COPY package.json pnpm-lock.yaml tsconfig.json tsconfig.build.json ./
 RUN pnpm install --frozen-lockfile
 COPY src/ ./src/
 COPY types/ ./types/
 RUN pnpm run build
 
-FROM node:16-alpine as remover
+FROM node:18-alpine as remover
 ARG NODE_ENV=production
 ENV NODE_ENV $NODE_ENV
 ENV AUTH_PORT 4000
 WORKDIR /app
-RUN npm i -g pnpm@8.5.1
+RUN npm i -g pnpm@8.6.2
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod  && pnpm store prune
 COPY migrations/ ./migrations/

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "typescript": "4.5.4"
   },
   "engines": {
-    "node": ">=16 <17"
+    "node": ">=18 <19"
   },
   "commitlint": {
     "extends": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@djgrant/postgres-migrations':

--- a/src/routes/signup/email-password.ts
+++ b/src/routes/signup/email-password.ts
@@ -1,10 +1,10 @@
 import { RequestHandler } from 'express';
 
-import { getSignInResponse, getUserByEmail, ENV } from '@/utils';
-import { UserRegistrationOptionsWithRedirect } from '@/types';
 import { sendError } from '@/errors';
-import { Joi, email, passwordInsert, registrationOptions } from '@/validation';
+import { UserRegistrationOptionsWithRedirect } from '@/types';
+import { ENV, getSignInResponse, getUserByEmail } from '@/utils';
 import { createUserAndSendVerificationEmail } from '@/utils/user/email-verification';
+import { Joi, email, passwordInsert, registrationOptions } from '@/validation';
 
 export const signUpEmailPasswordSchema = Joi.object({
   email: email.required(),
@@ -37,17 +37,14 @@ export const signUpEmailPasswordHandler: RequestHandler<
 
   // SIGNIN_EMAIL_VERIFIED_REQUIRED = true => User must verify their email before signing in.
   // SIGNIN_EMAIL_VERIFIED_REQUIRED = false => User don't have to verify their email before signin in.
-
-  if (!ENV.AUTH_EMAIL_SIGNIN_EMAIL_VERIFIED_REQUIRED) {
-    const signInResponse = await getSignInResponse({
-      userId: user.id,
-      checkMFA: false,
-    });
-
-    // return logged in session because user does not have to verify their email
-    // to sign in
-    return res.send(signInResponse);
+  if (ENV.AUTH_EMAIL_SIGNIN_EMAIL_VERIFIED_REQUIRED) {
+    return res.send({ session: null, mfa: null });
   }
 
-  return res.send({ session: null, mfa: null });
+  const signInResponse = await getSignInResponse({
+    userId: user.id,
+    checkMFA: false,
+  });
+
+  return res.send(signInResponse);
 };

--- a/src/utils/__generated__/graphql-request.ts
+++ b/src/utils/__generated__/graphql-request.ts
@@ -525,6 +525,13 @@ export type AuthRefreshTokenTypes_Mutation_Response = {
   returning: Array<AuthRefreshTokenTypes>;
 };
 
+/** input type for inserting object relation for remote table "auth.refresh_token_types" */
+export type AuthRefreshTokenTypes_Obj_Rel_Insert_Input = {
+  data: AuthRefreshTokenTypes_Insert_Input;
+  /** upsert condition */
+  on_conflict?: InputMaybe<AuthRefreshTokenTypes_On_Conflict>;
+};
+
 /** on_conflict condition type for table "auth.refresh_token_types" */
 export type AuthRefreshTokenTypes_On_Conflict = {
   constraint: AuthRefreshTokenTypes_Constraint;
@@ -594,6 +601,8 @@ export type AuthRefreshTokens = {
   id: Scalars['uuid'];
   metadata?: Maybe<Scalars['jsonb']>;
   refreshTokenHash?: Maybe<Scalars['String']>;
+  /** An object relationship */
+  refresh_token_type: AuthRefreshTokenTypes;
   type: AuthRefreshTokenTypes_Enum;
   /** An object relationship */
   user: Users;
@@ -668,6 +677,7 @@ export type AuthRefreshTokens_Bool_Exp = {
   id?: InputMaybe<Uuid_Comparison_Exp>;
   metadata?: InputMaybe<Jsonb_Comparison_Exp>;
   refreshTokenHash?: InputMaybe<String_Comparison_Exp>;
+  refresh_token_type?: InputMaybe<AuthRefreshTokenTypes_Bool_Exp>;
   type?: InputMaybe<AuthRefreshTokenTypes_Enum_Comparison_Exp>;
   user?: InputMaybe<Users_Bool_Exp>;
   userId?: InputMaybe<Uuid_Comparison_Exp>;
@@ -701,6 +711,7 @@ export type AuthRefreshTokens_Insert_Input = {
   id?: InputMaybe<Scalars['uuid']>;
   metadata?: InputMaybe<Scalars['jsonb']>;
   refreshTokenHash?: InputMaybe<Scalars['String']>;
+  refresh_token_type?: InputMaybe<AuthRefreshTokenTypes_Obj_Rel_Insert_Input>;
   type?: InputMaybe<AuthRefreshTokenTypes_Enum>;
   user?: InputMaybe<Users_Obj_Rel_Insert_Input>;
   userId?: InputMaybe<Scalars['uuid']>;
@@ -767,6 +778,7 @@ export type AuthRefreshTokens_Order_By = {
   id?: InputMaybe<Order_By>;
   metadata?: InputMaybe<Order_By>;
   refreshTokenHash?: InputMaybe<Order_By>;
+  refresh_token_type?: InputMaybe<AuthRefreshTokenTypes_Order_By>;
   type?: InputMaybe<Order_By>;
   user?: InputMaybe<Users_Order_By>;
   userId?: InputMaybe<Order_By>;


### PR DESCRIPTION
A lot of messages were missing from the production logs. The verbosity has slightly been increased in this PR.

This PR also bumps the required Node.js version to v18. [Node.js v16's EOL date has been brought forward] to this September(https://nodejs.org/en/blog/announcements/nodejs16-eol).