### PR TITLE
bugfix(hasura-auth) keep select and delete permissions already set in metadata for auth tables instead of overriding them

### DIFF
--- a/.changeset/flat-parrots-remain.md
+++ b/.changeset/flat-parrots-remain.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+fix: merge new select/delete permissions with the existing ones

--- a/src/utils/hasura-metadata/helpers.ts
+++ b/src/utils/hasura-metadata/helpers.ts
@@ -115,11 +115,17 @@ export const patchTableObject = (
   }
 
   if (select_permissions) {
-    existingTable.select_permissions = [...select_permissions];
+    const mergedSelectPermissions = [...(existingTable.select_permissions ?? []), ...select_permissions];
+    existingTable.select_permissions = [
+      ...new Map(mergedSelectPermissions.map((permission) => [permission.role, permission])).values()
+    ];
   }
 
   if (delete_permissions) {
-    existingTable.delete_permissions = [...delete_permissions];
+    const mergedDeletePermissions = [...(existingTable.delete_permissions ?? []), ...delete_permissions];
+    existingTable.delete_permissions = [
+      ...new Map(mergedDeletePermissions.map((permission) => [permission.role, permission])).values()
+    ];
   }
 
   // TODO merge other fields (permissions, computed fields, etc.) - not required by Hasura-auth yet


### PR DESCRIPTION
The documentation already mentions that it is possible to set permissions on auth tables.

Fixes https://github.com/nhost/hasura-auth/issues/406
