### PR TITLE
fix: use empty as AUTH_API_PREFIX default value

### DIFF
--- a/.changeset/chilly-penguins-relate.md
+++ b/.changeset/chilly-penguins-relate.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+fix: use empty as AUTH_API_PREFIX default value

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -35,7 +35,7 @@ export const ENV = {
     return castStringEnv('AUTH_SERVER_URL');
   },
   get AUTH_API_PREFIX() {
-    return castStringEnv('AUTH_API_PREFIX', '/');
+    return castStringEnv('AUTH_API_PREFIX', '');
   },
 
   // SMTP


### PR DESCRIPTION
### Checklist

- [X] No breaking changes
- [X] Tests pass