### PR TITLE
fix: conceal error if AUTH_CONCEAL_ERRORS is set

### DIFF
--- a/.changeset/healthy-eyes-drop.md
+++ b/.changeset/healthy-eyes-drop.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+fix: conceal error if AUTH_CONCEAL_ERRORS is set

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -169,17 +169,18 @@ export const sendError = (
   const isSensitive = ENV.AUTH_CONCEAL_ERRORS && !!ERRORS[code].sensitive;
   const error = isSensitive ? ERRORS['invalid-request'] : ERRORS[code];
   const message = (isSensitive ? null : customMessage) ?? error.message;
+  const errorCode = isSensitive ? 'invalid-request' : code;
   const status = error.status;
 
   if (forwardRedirection && redirectTo) {
     const redirectUrl = generateRedirectUrl(redirectTo, {
-      error: code,
+      error: errorCode,
       errorDescription: message,
     });
     return res.redirect(redirectUrl);
   }
 
-  return res.status(status).send({ status, message, error: code });
+  return res.status(status).send({ status, message, error: errorCode });
 };
 
 /**

--- a/test/routes/misc/__snapshots__/conceal-errors.test.ts.snap
+++ b/test/routes/misc/__snapshots__/conceal-errors.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`conceal error messages should conceal errors 1`] = `
 Object {
-  "error": "invalid-email-password",
+  "error": "invalid-request",
   "message": "The request payload is incorrect",
   "status": 400,
 }


### PR DESCRIPTION
Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass

### Changes

When AUTH_CONCEAL_ERRORS is used, the error code in the response is also concealed

### Tests

Snapshot for conceal-error.test.ts has been updated
