### PR TITLE
fix: added an index on refresh_tokens to improve lookup performance

### DIFF
--- a/.changeset/healthy-flies-doubt.md
+++ b/.changeset/healthy-flies-doubt.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': patch
+---
+
+Adding an index on refresh_tokens to increase performances

--- a/migrations/00016_index_on_refresh_tokens.sql
+++ b/migrations/00016_index_on_refresh_tokens.sql
@@ -1,4 +1,2 @@
-SET ROLE postgres;
-
 CREATE INDEX IF NOT EXISTS refresh_tokens_refresh_token_hash_expires_at_user_id_idx ON
   auth.refresh_tokens (refresh_token_hash, expires_at, user_id);

--- a/migrations/00016_index_on_refresh_tokens.sql
+++ b/migrations/00016_index_on_refresh_tokens.sql
@@ -1,0 +1,4 @@
+SET ROLE postgres;
+
+CREATE INDEX IF NOT EXISTS refresh_tokens_refresh_token_hash_expires_at_user_id_idx ON
+  auth.refresh_tokens (refresh_token_hash, expires_at, user_id);


### PR DESCRIPTION
Just adding an index on auth.refresh_tokens (refresh_token_hash, expires_at, user_id)

BEFORE :
<img width="734" alt="image" src="https://github.com/nhost/hasura-auth/assets/1137511/f124db95-e536-427d-aade-c195a307c700">

AFTER :
![image](https://github.com/nhost/hasura-auth/assets/1137511/656c4ef2-e400-4482-9e0e-30cb4b16b963)
