### PR TITLE
feat: allow connecting social logins to existing users even if emails don't match

### DIFF
--- a/.changeset/heavy-clouds-jump.md
+++ b/.changeset/heavy-clouds-jump.md
@@ -1,0 +1,5 @@
+---
+'hasura-auth': minor
+---
+
+feat: allow connecting social logins to existing users even if emails don't match

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -111,6 +111,10 @@ export const ERRORS = asErrors({
     status: StatusCodes.BAD_REQUEST,
     message: 'Logged in user is not anonymous',
   },
+  'forbidden': {
+    status: StatusCodes.FORBIDDEN,
+    message: 'Forbidden',
+  },
   'forbidden-anonymous': {
     status: StatusCodes.FORBIDDEN,
     message: 'Anonymous users cannot access this endpoint',

--- a/src/routes/oauth/index.ts
+++ b/src/routes/oauth/index.ts
@@ -347,7 +347,6 @@ export const oauthProviders = Router()
     if (user) {
       const { refreshToken } = await getNewRefreshToken(user.id);
       // * redirect back user to app url
-      console.log('redirecting to', generateRedirectUrl(redirectTo, { refreshToken }));
       return res.redirect(generateRedirectUrl(redirectTo, { refreshToken }));
     }
 

--- a/src/routes/oauth/index.ts
+++ b/src/routes/oauth/index.ts
@@ -3,7 +3,9 @@ import { logger } from '@/logger';
 import {
   ENV,
   generateRedirectUrl,
+  getClaims,
   getNewRefreshToken,
+  getUserById,
   getUserByEmail,
   gqlSdk,
   insertUser,
@@ -179,7 +181,6 @@ export const oauthProviders = Router()
       }
     }
 
-
     // * Destroy the session as it is only needed for the oauth flow
     await new Promise((resolve) => {
       session.destroy(() => {
@@ -255,7 +256,40 @@ export const oauthProviders = Router()
       providerUserId,
     });
 
-    if (authUserProvider) {
+    if (typeof options?.connect === 'string') {
+      if (authUserProvider) {
+        logger.error('social user already exists');
+        return sendErrorFromQuery('bad-request', 'social user already exists');
+      }
+
+      let claims;
+      try {
+        claims = await getClaims(options.connect);
+      } catch (err) {
+        logger.error(`Could not get claims: ${err}`);
+        return sendErrorFromQuery('forbidden', 'JWT is invalid');
+      }
+
+      user = await getUserById(claims['x-hasura-user-id']);
+      if (!user) {
+        return sendErrorFromQuery('user-not-found','User not found');
+      }
+
+      const { insertAuthUserProvider } =
+        await gqlSdk.insertUserProviderToUser({
+          userProvider: {
+            userId: user.id,
+            providerId: provider,
+            providerUserId,
+            accessToken,
+            refreshToken,
+          },
+        });
+
+      if (!insertAuthUserProvider) {
+          return sendErrorFromQuery('internal-error', 'Could not add a provider to user');
+      }
+    } else if (authUserProvider) {
       // * The userProvider already exists. Update it with the new tokens
       user = authUserProvider.user;
       await gqlSdk.updateAuthUserprovider({
@@ -313,6 +347,7 @@ export const oauthProviders = Router()
     if (user) {
       const { refreshToken } = await getNewRefreshToken(user.id);
       // * redirect back user to app url
+      console.log('redirecting to', generateRedirectUrl(redirectTo, { refreshToken }));
       return res.redirect(generateRedirectUrl(redirectTo, { refreshToken }));
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type UserRegistrationOptions = {
   allowedRoles: string[];
   defaultRole: string;
   displayName?: string;
+  connect?: string;
   metadata: Metadata;
 };
 

--- a/src/utils/user/getters.ts
+++ b/src/utils/user/getters.ts
@@ -63,6 +63,22 @@ export const getUser = async ({
   };
 };
 
+export const getUserById = async (id: string) => {
+  const { users } = await gqlSdk.users({
+    where: {
+      id: {
+        _eq: id,
+      },
+    },
+  });
+
+  if (users.length !== 1) {
+    return null;
+  }
+
+  return users[0];
+};
+
 export const getUserByEmail = async (email: string) => {
   const { users } = await gqlSdk.users({
     where: {


### PR DESCRIPTION
When calling `/oauth/:provider` adds a new query arg `connect` which needs to contain a valid JWT. If the social login doesn't already exist, sign-ins successfully and the JWT belongs to a valid user, the social login is connected to the user even if the email addresses don't match.

Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [ ] New features have new tests
- [ ] Documentation is updated

### Breaking changes

Avoid breaking changes and regressions. If you feel it is unavoidable, make it explicit in your PR comment so we can review it and see how to handle it.

### Tests

- please make sure your changes pass the current tests (Use the `make test` or the `make watch` command).
- if you are introducing a new feature, please write as much tests as possible.

### Documentation

Please make sure the documentation is updated accordingly, in particular:

- [Workflows](https://github.com/nhost/hasura-auth/tree/main/docs/workflows). Workflows are [Mermaid sequence diagrams](https://mermaid-js.github.io/mermaid/#/sequenceDiagram)
- [Schema](https://github.com/nhost/hasura-auth/blob/main/docs/schema.md). The schema in a [Mermaid ER diagram](https://mermaid-js.github.io/mermaid/#/entityRelationshipDiagram)
- [Environment variables](https://github.com/nhost/hasura-auth/blob/main/docs/environment-variables.md). Please adjust the [.env.example](https://github.com/nhost/hasura-auth/blob/main/.env.example) file accordingly
- OpenApi specifications. We are using inline [JSDoc annotations](https://www.npmjs.com/package/express-jsdoc-swagger)
