### PR TITLE
fix: now supporting allowed email/domain combo rules

### DIFF
--- a/go/controller/validator.go
+++ b/go/controller/validator.go
@@ -121,11 +121,8 @@ func ValidateEmail(
 			return false
 		}
 
-		if len(allowedEmailDomains) > 0 && !slices.Contains(allowedEmailDomains, domain) {
-			return false
-		}
-
-		if len(allowedEmails) > 0 && !slices.Contains(allowedEmails, email) {
+		if (len(allowedEmailDomains) > 0 && !slices.Contains(allowedEmailDomains, domain)) &&
+			(len(allowedEmails) > 0 && !slices.Contains(allowedEmails, email)) {
 			return false
 		}
 

--- a/go/controller/validator_test.go
+++ b/go/controller/validator_test.go
@@ -258,6 +258,24 @@ func TestValidateEmail(t *testing.T) {
 			email:          "test@acme.se",
 			expected:       false,
 		},
+		{
+			name:           "allowed email or domain match",
+			blockedDomains: []string{},
+			blockedEmails:  []string{},
+			allowedDomains: []string{"example.com"},
+			allowedEmails:  []string{"test@acme.com"},
+			email:          "test@acme.com",
+			expected:       true,
+		},
+		{
+			name:           "allowed email or domain not match",
+			blockedDomains: []string{},
+			blockedEmails:  []string{},
+			allowedDomains: []string{"example.com"},
+			allowedEmails:  []string{"test@acme.com"},
+			email:          "test@example.in",
+			expected:       false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [ ] Documentation is updated

### Breaking changes

Avoid breaking changes and regressions. If you feel it is unavoidable, make it explicit in your PR comment so we can review it and see how to handle it.

### Tests

- please make sure your changes pass the current tests (Use the `make test` or the `make watch` command).
- if you are introducing a new feature, please write as much tests as possible.

### Documentation

Please make sure the documentation is updated accordingly, in particular:

- [Workflows](https://github.com/nhost/hasura-auth/tree/main/docs/workflows). Workflows are [Mermaid sequence diagrams](https://mermaid-js.github.io/mermaid/#/sequenceDiagram)
- [Schema](https://github.com/nhost/hasura-auth/blob/main/docs/schema.md). The schema in a [Mermaid ER diagram](https://mermaid-js.github.io/mermaid/#/entityRelationshipDiagram)
- [Environment variables](https://github.com/nhost/hasura-auth/blob/main/docs/environment-variables.md). Please adjust the [.env.example](https://github.com/nhost/hasura-auth/blob/main/.env.example) file accordingly
- OpenApi specifications. We are using inline [JSDoc annotations](https://www.npmjs.com/package/express-jsdoc-swagger)

Now supporting combination of **allowed** `email/domain` rules as described in the [docs](https://github.com/nhost/hasura-auth/blob/main/docs/configuration.md#email-checks)
 
```
AUTH_ACCESS_CONTROL_ALLOWED_EMAILS=bob@smith.com
AUTH_ACCESS_CONTROL_ALLOWED_EMAIL_DOMAINS=nhost.io,example.com
```

In the above example, users with the following emails would be able to register bob@smith.com, emma@example.com, john@nhost.io, whereas mary@firebase.com won't.
