### PR TITLE
fix: dont crash if users have no roles when refreshing token

### DIFF
--- a/go/controller/workflows.go
+++ b/go/controller/workflows.go
@@ -314,9 +314,15 @@ func (wf *Workflows) UpdateSession(
 		return &api.Session{}, ErrInvalidRefreshToken //nolint:exhaustruct
 	}
 
-	allowedRoles := make([]string, len(userRoles))
-	for i, role := range userRoles {
-		allowedRoles[i] = role.Role
+	allowedRoles := make([]string, 0, len(userRoles))
+	for _, role := range userRoles {
+		if role.Role.Valid {
+			allowedRoles = append(allowedRoles, role.Role.String)
+		}
+	}
+
+	if !slices.Contains(allowedRoles, user.DefaultRole) {
+		allowedRoles = append(allowedRoles, user.DefaultRole)
 	}
 
 	accessToken, expiresIn, err := wf.jwtGetter.GetToken(

--- a/go/sql/query.sql
+++ b/go/sql/query.sql
@@ -159,7 +159,7 @@ updated_user AS (
     WHERE auth.users.id = refreshed_token.user_id
 )
 SELECT refreshed_token.refresh_token_id, role FROM auth.user_roles
-JOIN refreshed_token ON auth.user_roles.user_id = refreshed_token.user_id;
+RIGHT JOIN refreshed_token ON auth.user_roles.user_id = refreshed_token.user_id;
 
 -- name: UpdateUserLastSeen :one
 UPDATE auth.users

--- a/go/sql/query.sql.go
+++ b/go/sql/query.sql.go
@@ -541,7 +541,7 @@ updated_user AS (
     WHERE auth.users.id = refreshed_token.user_id
 )
 SELECT refreshed_token.refresh_token_id, role FROM auth.user_roles
-JOIN refreshed_token ON auth.user_roles.user_id = refreshed_token.user_id
+RIGHT JOIN refreshed_token ON auth.user_roles.user_id = refreshed_token.user_id
 `
 
 type RefreshTokenAndGetUserRolesParams struct {
@@ -551,7 +551,7 @@ type RefreshTokenAndGetUserRolesParams struct {
 
 type RefreshTokenAndGetUserRolesRow struct {
 	RefreshTokenID uuid.UUID
-	Role           string
+	Role           pgtype.Text
 }
 
 func (q *Queries) RefreshTokenAndGetUserRoles(ctx context.Context, arg RefreshTokenAndGetUserRolesParams) ([]RefreshTokenAndGetUserRolesRow, error) {


### PR DESCRIPTION
For some strange reason I don't understand some users have users without any "allowed roles". This shouldn't happen but, in any case, this should avoid crashing in such cases.