### PR TITLE
fix: correctly display error message when metadata migration fails

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -449,6 +449,6 @@ export const applyMetadata = async (): Promise<void> => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const error = e as any;
     const message = error.response?.data || error.message;
-    logger.warn('Impossible to apply metadata', message);
+    logger.warn('Impossible to apply metadata: ${message}');
   }
 };


### PR DESCRIPTION
Before submitting this PR:

### Checklist

- [x] No breaking changes
- [x] Tests pass
- [x] New features have new tests
- [x] Documentation is updated

