### PR TITLE
fix: change hasura health check url to make auth server work in gcp

### DIFF
--- a/src/utils/hasura.ts
+++ b/src/utils/hasura.ts
@@ -9,7 +9,7 @@ function delay(ms: number) {
 const reachHasura = async () => {
   try {
     await axios.get(
-      `${ENV.HASURA_GRAPHQL_GRAPHQL_URL.replace('/v1/graphql', '/healthz')}`
+      `${ENV.HASURA_GRAPHQL_GRAPHQL_URL.replace('/v1/graphql', '/hasura/healthz')}`
     );
   } catch (err) {
     const { message } = err as AxiosError;


### PR DESCRIPTION
Google cloud doesnt support "z" urls - https://stackoverflow.com/questions/43380939/where-does-the-convention-of-using-healthz-for-application-health-checks-come-f

And hasura provides an alternate end point for this https://hasura.io/docs/2.0/api-reference/health/ .

### Checklist

- [ ] No breaking changes
- [X] Tests pass
- [X] New features have new tests
- [ ] Documentation is updated

