### PR TITLE
fix: add missing kid to JWT header

### DIFF
--- a/go/controller/jwt.go
+++ b/go/controller/jwt.go
@@ -123,6 +123,7 @@ type CustomClaimer interface {
 type JWTGetter struct {
 	claimsNamespace      string
 	issuer               string
+	kid                  string
 	signingKey           any
 	validatingKey        any
 	method               jwt.SigningMethod
@@ -151,6 +152,7 @@ func NewJWTGetter(
 		claimsNamespace:      jwtSecret.ClaimsNamespace,
 		issuer:               jwtSecret.Issuer,
 		signingKey:           jwtSecret.SigningKey,
+		kid:                  jwtSecret.KeyID,
 		validatingKey:        jwtSecret.Key,
 		method:               method,
 		customClaimer:        customClaimer,
@@ -240,6 +242,9 @@ func (j *JWTGetter) GetToken(
 		j.claimsNamespace: c,
 	}
 	token := jwt.NewWithClaims(j.method, claims)
+	if j.kid != "" {
+		token.Header["kid"] = j.kid
+	}
 	ss, err := token.SignedString(j.signingKey)
 	if err != nil {
 		return "", 0, fmt.Errorf("error signing token: %w", err)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a `kid` field to the `JWTGetter` struct to include the Key ID in the JWT header.
- Initialized the `kid` field in the `NewJWTGetter` function using the `jwtSecret.KeyID`.
- Modified the `GetToken` method to include the `kid` in the JWT header if it is not empty.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jwt.go</strong><dd><code>Add missing `kid` to JWT header in `JWTGetter`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/controller/jwt.go

<li>Added <code>kid</code> field to <code>JWTGetter</code> struct.<br> <li> Initialized <code>kid</code> field in <code>NewJWTGetter</code> function.<br> <li> Included <code>kid</code> in JWT header if present in <code>GetToken</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/585/files#diff-2b63f932811bd25d3716aca99c9a61a691d412f94ab1ce61d85768deb84d3dd9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information