### PR TITLE
fix: always set ticket expires at as it can't be null

### DIFF
--- a/go/controller/post_signin_idtoken_test.go
+++ b/go/controller/post_signin_idtoken_test.go
@@ -356,7 +356,7 @@ func TestPostSigninIdToken(t *testing.T) { //nolint:maintidx
 						AvatarUrl:       "https://myapp.local/jane.jpg",
 						Email:           sql.Text("jane@myapp.local"),
 						Ticket:          sql.Text(""),
-						TicketExpiresAt: pgtype.Timestamptz{}, //nolint:exhaustruct
+						TicketExpiresAt: sql.TimestampTz(time.Now()),
 						EmailVerified:   true,
 						Locale:          "en",
 						DefaultRole:     "user",
@@ -467,7 +467,7 @@ func TestPostSigninIdToken(t *testing.T) { //nolint:maintidx
 						TotpSecret:               pgtype.Text{},
 						ActiveMfaType:            pgtype.Text{},
 						Ticket:                   pgtype.Text{},
-						TicketExpiresAt:          pgtype.Timestamptz{},
+						TicketExpiresAt:          sql.TimestampTz(time.Now()),
 						Metadata:                 []byte{},
 						WebauthnCurrentChallenge: pgtype.Text{},
 					}, nil)
@@ -601,7 +601,7 @@ func TestPostSigninIdToken(t *testing.T) { //nolint:maintidx
 						TotpSecret:               pgtype.Text{},
 						ActiveMfaType:            pgtype.Text{},
 						Ticket:                   pgtype.Text{},
-						TicketExpiresAt:          pgtype.Timestamptz{},
+						TicketExpiresAt:          sql.TimestampTz(time.Now()),
 						Metadata:                 []byte{},
 						WebauthnCurrentChallenge: pgtype.Text{},
 					}, nil)
@@ -730,7 +730,7 @@ func TestPostSigninIdToken(t *testing.T) { //nolint:maintidx
 						TotpSecret:               pgtype.Text{},
 						ActiveMfaType:            pgtype.Text{},
 						Ticket:                   pgtype.Text{},
-						TicketExpiresAt:          pgtype.Timestamptz{},
+						TicketExpiresAt:          sql.TimestampTz(time.Now()),
 						Metadata:                 []byte{},
 						WebauthnCurrentChallenge: pgtype.Text{},
 					}, nil)

--- a/go/controller/workflows.go
+++ b/go/controller/workflows.go
@@ -819,7 +819,7 @@ func (wf *Workflows) SignupUserWithouthSession(
 	gravatarURL := wf.gravatarURL(email)
 
 	var ticket pgtype.Text
-	var ticketExpiresAt pgtype.Timestamptz
+	ticketExpiresAt := sql.TimestampTz(time.Now())
 	if sendConfirmationEmail {
 		ticket = sql.Text(generateTicket(TicketTypeVerifyEmail))
 		ticketExpiresAt = sql.TimestampTz(time.Now().Add(InAMonth))


### PR DESCRIPTION
Fixes https://github.com/nhost/nhost/issues/3035

### **PR Type**
Bug fix


___

### **Description**
- Updated `TicketExpiresAt` field in multiple test cases to use `sql.TimestampTz(time.Now())` ensuring it is always set to a non-null value.
- Modified `ticketExpiresAt` initialization in `SignupUserWithouthSession` method to ensure it is always set to a non-null value.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>post_signin_idtoken_test.go</strong><dd><code>Set non-null `TicketExpiresAt` in test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/controller/post_signin_idtoken_test.go

<li>Updated <code>TicketExpiresAt</code> field to use <code>sql.TimestampTz(time.Now())</code> <br>instead of <code>pgtype.Timestamptz{}</code>.<br> <li> Ensured <code>TicketExpiresAt</code> is always set to a non-null value in test <br>cases.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/588/files#diff-d849cc9b72340eb39d633b2446f3223cb202e09cabdef07b5ce512f15fc129f2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflows.go</strong><dd><code>Ensure `ticketExpiresAt` is non-null during user signup</code>&nbsp; &nbsp; </dd></summary>
<hr>

go/controller/workflows.go

<li>Changed <code>ticketExpiresAt</code> initialization to use <br><code>sql.TimestampTz(time.Now())</code>.<br> <li> Ensured <code>ticketExpiresAt</code> is always set to a non-null value.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/588/files#diff-6aaacc47584f1edde5a01051611a7baffc583fc32b48df6d7fee39afa16a65cb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information