### PR TITLE
fix: signin/idtoken: insert user provider if user provider not found

### DIFF
--- a/go/controller/post_signin_idtoken_test.go
+++ b/go/controller/post_signin_idtoken_test.go
@@ -606,6 +606,26 @@ func TestPostSigninIdToken(t *testing.T) { //nolint:maintidx
 						WebauthnCurrentChallenge: pgtype.Text{},
 					}, nil)
 
+				mock.EXPECT().InsertUserProvider(
+					gomock.Any(),
+					sql.InsertUserProviderParams{
+						UserID:         userID,
+						ProviderID:     "fake",
+						ProviderUserID: "106964149809169421082",
+					},
+				).Return(
+					sql.AuthUserProvider{
+						ID:             userID,
+						CreatedAt:      pgtype.Timestamptz{}, //nolint:exhaustruct
+						UpdatedAt:      pgtype.Timestamptz{}, //nolint:exhaustruct
+						UserID:         userID,
+						AccessToken:    "unset",
+						RefreshToken:   pgtype.Text{}, //nolint:exhaustruct
+						ProviderID:     "fake",
+						ProviderUserID: "106964149809169421082",
+					}, nil,
+				)
+
 				mock.EXPECT().GetUserRoles(
 					gomock.Any(), userID,
 				).Return([]sql.AuthUserRole{


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new boolean return value in `postSigninIdtokenCheckUserExists` to indicate if the provider was found.
- Updated `PostSigninIdtoken` to handle the new return value and insert the user provider if not found.
- Enhanced test cases to mock and verify the insertion of user provider during sign-in.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>post_signin_idtoken.go</strong><dd><code>Handle missing user provider during sign-in</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/controller/post_signin_idtoken.go

<li>Added a new boolean return value to indicate if the provider was <br>found.<br> <li> Updated the <code>postSigninIdtokenCheckUserExists</code> function to handle the <br>new return value.<br> <li> Modified the <code>PostSigninIdtoken</code> function to use the new return value.<br> <li> Inserted user provider if not found during sign-in.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/590/files#diff-9fd0de4be8562a869563cff72a27f579c9c45d66d9f6d4754a9dd20498514b53">+26/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>post_signin_idtoken_test.go</strong><dd><code>Add tests for inserting user provider during sign-in</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/controller/post_signin_idtoken_test.go

<li>Added test cases to mock <code>InsertUserProvider</code> function.<br> <li> Verified the insertion of user provider when not found.<br>


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/590/files#diff-d849cc9b72340eb39d633b2446f3223cb202e09cabdef07b5ce512f15fc129f2">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information