### PR TITLE
feat: custom-claims: allow filtered jsonpath

### DIFF
--- a/go/controller/custom_claims.go
+++ b/go/controller/custom_claims.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -19,9 +21,7 @@ import (
 func mergeMaps(map1, map2 map[string]any) map[string]any {
 	result := make(map[string]any)
 
-	for key, val := range map1 {
-		result[key] = val
-	}
+	maps.Copy(result, map1)
 
 	for key, val := range map2 {
 		if v, ok := result[key]; ok {
@@ -76,6 +76,52 @@ func smartSplit(path string) []string {
 	}
 
 	return parts
+}
+
+func extractFilterFields(filter string) []string { //nolint:cyclop,gocognit
+	var fields []string
+	// Extract fields from JSONPath filter expressions like [?(@.field == 'value')]
+	if strings.Contains(filter, "[?") { //nolint:nestif
+		// Find all @.fieldName patterns
+		start := strings.Index(filter, "[?")
+		if start != -1 {
+			end := strings.Index(filter[start:], "]")
+			if end != -1 {
+				filterExpr := filter[start+2 : start+end] // Extract the filter expression
+				// Look for @.fieldName patterns
+				for i := 0; i < len(filterExpr); {
+					atIndex := strings.Index(filterExpr[i:], "@.")
+					if atIndex == -1 {
+						break
+					}
+					atIndex += i
+					fieldStart := atIndex + 2 //nolint:mnd
+					fieldEnd := fieldStart
+					// Find the end of the field name (stop at space, ), ==, !=, etc.)
+					for fieldEnd < len(filterExpr) {
+						char := filterExpr[fieldEnd]
+						if char == ' ' || char == ')' || char == '=' || char == '!' || char == '<' || char == '>' {
+							break
+						}
+						fieldEnd++
+					}
+					if fieldEnd > fieldStart {
+						field := filterExpr[fieldStart:fieldEnd]
+						// Only add if not already present
+						found := false
+						if slices.Contains(fields, field) {
+							break
+						}
+						if !found {
+							fields = append(fields, field)
+						}
+					}
+					i = fieldEnd
+				}
+			}
+		}
+	}
+	return fields
 }
 
 func parseClaims(parts []string) map[string]any {
@@ -162,6 +208,33 @@ func NewCustomClaims(
 	for name, val := range rawClaims {
 		parts := smartSplit(val)
 		claims = mergeMaps(claims, parseClaims(parts))
+
+		// Extract and add filter fields if this is a JSONPath filter expression
+		if strings.Contains(val, "[?") { //nolint:nestif
+			filterFields := extractFilterFields(val)
+			if len(filterFields) > 0 {
+				// Create a structure to add the filter fields to the appropriate location
+				filterParts := smartSplit(val)
+				if len(filterParts) > 0 {
+					// Find the part with the filter and remove everything after the base field name
+					baseParts := make([]string, 0, len(filterParts))
+					for _, part := range filterParts {
+						if strings.Contains(part, "[?") {
+							// Extract just the field name before the filter
+							basePart := strings.Split(part, "[")[0]
+							baseParts = append(baseParts, basePart)
+							break
+						}
+						baseParts = append(baseParts, part)
+					}
+
+					// Create claims for each filter field
+					for _, field := range filterFields {
+						claims = mergeMaps(claims, parseClaims(append(baseParts, field)))
+					}
+				}
+			}
+		}
 
 		j := jsonpath.New(name)
 		jpath := fmt.Sprintf("{ .%s }", strings.ReplaceAll(val, "[]", "[*]"))
@@ -250,9 +323,9 @@ func (c *CustomClaims) ExtractClaims(data any) (map[string]any, error) {
 
 func (c *CustomClaims) makeRequest(ctx context.Context, userID string) (map[string]any, error) {
 	buf := new(bytes.Buffer)
-	if err := json.NewEncoder(buf).Encode(map[string]interface{}{
+	if err := json.NewEncoder(buf).Encode(map[string]any{
 		"query": c.graphqlQuery,
-		"variables": map[string]interface{}{
+		"variables": map[string]any{
 			"id": userID,
 		},
 	}); err != nil {

--- a/go/controller/custom_claims.go
+++ b/go/controller/custom_claims.go
@@ -100,7 +100,9 @@ func extractFilterFields(filter string) []string { //nolint:cyclop,gocognit
 					// Find the end of the field name (stop at space, ), ==, !=, etc.)
 					for fieldEnd < len(filterExpr) {
 						char := filterExpr[fieldEnd]
-						if char == ' ' || char == ')' || char == '=' || char == '!' || char == '<' || char == '>' {
+						if char == ' ' || char == ')' || char == '=' || char == '!' ||
+							char == '<' ||
+							char == '>' {
 							break
 						}
 						fieldEnd++
@@ -180,7 +182,8 @@ type jsonPath struct {
 }
 
 func (j jsonPath) IsArrary() bool {
-	return strings.Contains(j.path, "[]") || strings.Contains(j.path, "[*]") || strings.Contains(j.path, "[?")
+	return strings.Contains(j.path, "[]") || strings.Contains(j.path, "[*]") ||
+		strings.Contains(j.path, "[?")
 }
 
 type CustomClaims struct {

--- a/go/controller/custom_claims_test.go
+++ b/go/controller/custom_claims_test.go
@@ -72,7 +72,7 @@ func TestCustomClaims(t *testing.T) {
 				"nonexistent":       "nonexistent.nonexistent",
 				"filtered":          "m.d[?(@.v == 'a')].id",
 			},
-			expectedGraphql: "query GetClaims($id: uuid!) { user(id:$id) {m{d{id }k l l2 lm{id }}metadata nonexistent{nonexistent }} }", //nolint:lll
+			expectedGraphql: "query GetClaims($id: uuid!) { user(id:$id) {m{d{id v }k l l2 lm{id }}metadata nonexistent{nonexistent }} }", //nolint:lll
 			expectedData: map[string]any{
 				"root":              data["m"],
 				"key":               "v",

--- a/go/controller/custom_claims_test.go
+++ b/go/controller/custom_claims_test.go
@@ -30,6 +30,20 @@ func TestCustomClaims(t *testing.T) {
 					map[string]any{"id": 4},
 				},
 			},
+			"d": []any{
+				map[string]any{
+					"id": 1,
+					"v":  "a",
+				},
+				map[string]any{
+					"id": 2,
+					"v":  "b",
+				},
+				map[string]any{
+					"id": 3,
+					"v":  "a",
+				},
+			},
 		},
 		"metadata": map[string]any{
 			"m1": 1,
@@ -56,8 +70,9 @@ func TestCustomClaims(t *testing.T) {
 				"arrayOneElement[]": "m.l2[]",
 				"metadata.m1":       "metadata.m1",
 				"nonexistent":       "nonexistent.nonexistent",
+				"filtered":          "m.d[?(@.v == 'a')].id",
 			},
-			expectedGraphql: "query GetClaims($id: uuid!) { user(id:$id) {m{k l l2 lm{id }}metadata nonexistent{nonexistent }} }", //nolint:lll
+			expectedGraphql: "query GetClaims($id: uuid!) { user(id:$id) {m{d{id }k l l2 lm{id }}metadata nonexistent{nonexistent }} }", //nolint:lll
 			expectedData: map[string]any{
 				"root":              data["m"],
 				"key":               "v",
@@ -70,6 +85,10 @@ func TestCustomClaims(t *testing.T) {
 				"array.ids[]":       []any{1, 2, 3},
 				"metadata.m1":       1,
 				"nonexistent":       nil,
+				"filtered": []any{
+					1,
+					3,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### **User description**
for instance, something like:

```toml
[[auth.session.accessToken.customClaims]]
key = 'department-manager'
value = 'departments[?(@.role == "manager")].id'

[[auth.session.accessToken.customClaims]]
key = 'department-member'
value = 'departments[?(@.role == "member")].id'
```


___

### **PR Type**
Enhancement


___

### **Description**
• Add support for JSONPath filter expressions in custom claims
• Implement smart path splitting to handle bracket notation
• Extract filter fields for proper GraphQL query generation
• Refactor map operations using Go's built-in maps package


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>custom_claims.go</strong><dd><code>Implement JSONPath filter expression support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/controller/custom_claims.go

• Add <code>smartSplit</code> function to handle JSONPath expressions with brackets<br> <br>• Implement <code>extractFilterFields</code> to parse filter expressions like <br><code>[?(@.field == 'value')]</code><br> • Update <code>IsArrary</code> method to detect filter <br>expressions<br> • Refactor map copying using <code>maps.Copy</code> instead of manual <br>iteration


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/651/files#diff-c548bbd2d2f0049972a2e9f4109812ad085354f2ad80f33d5faffb7fbbbcf71a">+112/-7</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>custom_claims_test.go</strong><dd><code>Add tests for JSONPath filter functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/controller/custom_claims_test.go

• Add test data with filterable array structure<br> • Include test case <br>for filtered JSONPath expression <code>m.d[?(@.v == 'a')].id</code><br> • Update <br>expected GraphQL query to include filter field dependencies<br> • Add <br>expected filtered results validation


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/651/files#diff-fe8259aacd678b29540bb6ae15315e7465f5f12299e27b68bdfb0cc6206f7bd1">+20/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>