### PR TITLE
fix: simplify email extraction to just look for < >

### DIFF
--- a/go/notifications/email.go
+++ b/go/notifications/email.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net/smtp"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -54,11 +53,11 @@ func sanitize(s string) string {
 // ExtractEmail returns the email address from a string that may be formatted
 // as "Display Name <email@example.com>" or just "email@example.com".
 func ExtractEmail(address string) string {
-	re := regexp.MustCompile(`<?(\w+(\W\w+)*@.\w+(\.\w+)*)>?`)
-	if match := re.FindStringSubmatch(address); len(match) > 1 {
-		return match[1]
+	if start := strings.Index(address, "<"); start != -1 {
+		if end := strings.Index(address[start:], ">"); end != -1 {
+			return address[start+1 : start+end]
+		}
 	}
-
 	return address
 }
 

--- a/go/notifications/email_test.go
+++ b/go/notifications/email_test.go
@@ -29,7 +29,7 @@ func TestExtractEmail(t *testing.T) {
 		{
 			name:     "malformed email - no closing bracket",
 			input:    "Test User <user@example.com",
-			expected: "user@example.com", // The regex should still match
+			expected: "Test User <user@example.com", // No closing bracket, return original
 		},
 		{
 			name:     "email with display name containing brackets",
@@ -39,7 +39,7 @@ func TestExtractEmail(t *testing.T) {
 		{
 			name:     "multiple email addresses in string",
 			input:    "user1@example.com, user2@example.com",
-			expected: "user1@example.com", // Should extract the first one
+			expected: "user1@example.com, user2@example.com", // No brackets, return original
 		},
 		{
 			name:     "complex display name",
@@ -60,6 +60,16 @@ func TestExtractEmail(t *testing.T) {
 			name:     "email with + character",
 			input:    "john+test@example.com",
 			expected: "john+test@example.com",
+		},
+		{
+			name:     "email with hyphen in domain",
+			input:    "user@ex-ample.com",
+			expected: "user@ex-ample.com",
+		},
+		{
+			name:     "email with hyphen in display name",
+			input:    "John-Doe <user@ex-ample.com>",
+			expected: "user@ex-ample.com",
 		},
 		{
 			name:     "invalid input without @",


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Simplify email extraction logic from regex to string operations

- Remove regex dependency for better performance

- Update test expectations for malformed email handling

- Add new test cases for hyphenated domains and names


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>email.go</strong><dd><code>Replace regex with string operations for email extraction</code></dd></summary>
<hr>

go/notifications/email.go

<li>Replace regex-based email extraction with simple string operations <br>using <code>strings.Index</code><br> <li> Remove <code>regexp</code> import dependency<br> <li> Simplify logic to only extract emails enclosed in angle brackets


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/655/files#diff-23fa6c5970f0d27bd2b007e64626e30c82dd1f5c19391dcbfe544e26f393ea86">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>email_test.go</strong><dd><code>Update tests for simplified email extraction logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/notifications/email_test.go

<li>Update expected results for malformed email test cases<br> <li> Change behavior for strings without angle brackets to return original <br>input<br> <li> Add two new test cases for hyphenated domains and display names


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/655/files#diff-15b6541fe822c5bba389b86f6988a6ef20b0b694703889f84acf4d5013df7c18">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>