### PR TITLE
fix: minor backward compatibility changes

### DIFF
--- a/go/cmd/migrations.go
+++ b/go/cmd/migrations.go
@@ -50,7 +50,7 @@ func applyMigrations(
 	ctx context.Context, cCtx *cli.Context, db *sql.Queries, logger *slog.Logger,
 ) error {
 	if err := migrations.ApplyPostgresMigration(
-		cCtx.String(flagPostgresConnection), logger,
+		cCtx.String(flagPostgresMigrationsConnection), logger,
 	); err != nil {
 		logger.Error("failed to apply migrations", slog.String("error", err.Error()))
 		return fmt.Errorf("failed to apply migrations: %w", err)

--- a/go/cmd/migrations.go
+++ b/go/cmd/migrations.go
@@ -49,9 +49,12 @@ func insertRoles(
 func applyMigrations(
 	ctx context.Context, cCtx *cli.Context, db *sql.Queries, logger *slog.Logger,
 ) error {
-	if err := migrations.ApplyPostgresMigration(
-		cCtx.String(flagPostgresMigrationsConnection), logger,
-	); err != nil {
+	postgresURL := cCtx.String(flagPostgresMigrationsConnection)
+	if postgresURL == "" {
+		postgresURL = cCtx.String(flagPostgresConnection)
+	}
+
+	if err := migrations.ApplyPostgresMigration(postgresURL, logger); err != nil {
 		logger.Error("failed to apply migrations", slog.String("error", err.Error()))
 		return fmt.Errorf("failed to apply migrations: %w", err)
 	}

--- a/go/cmd/serve.go
+++ b/go/cmd/serve.go
@@ -1305,6 +1305,16 @@ func getGoServer( //nolint:funlen
 		router.POST(cCtx.String(flagAPIPrefix)+"/change-env", ctrl.PostChangeEnv)
 	}
 
+	// for backwards compatibility we keep these two endpoints without the prefix
+	if cCtx.String(flagAPIPrefix) != "" {
+		router.GET("/healthz", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		})
+		router.HEAD("/healthz", func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		})
+	}
+
 	server := &http.Server{ //nolint:exhaustruct
 		Addr:              ":" + cCtx.String(flagPort),
 		Handler:           router,

--- a/go/migrations/postgres.go
+++ b/go/migrations/postgres.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
@@ -73,6 +74,12 @@ func migrateMigrationsFromNodejs(
 }
 
 func ApplyPostgresMigration(postgresURL string, logger *slog.Logger) error {
+	// for backward compatibility, we ensure that the postgresURL contains the sslmode parameter
+	// if it doesn't, we default to "disable"
+	if !strings.Contains(postgresURL, "sslmode") {
+		postgresURL += "?sslmode=disable"
+	}
+
 	db, err := sql.Open("postgres", postgresURL)
 	if err != nil {
 		return fmt.Errorf("problem connecting to postgres: %w", err)

--- a/go/migrations/postgres.go
+++ b/go/migrations/postgres.go
@@ -18,11 +18,9 @@ const schemaName = "auth"
 //go:embed postgres/*.sql
 var postgresMigrations embed.FS
 
-func migrateMigrationsFromNodejs(
+func checkIfWeNeedToMigrate(
 	db *sql.DB,
-	migration *migrate.Migrate,
-	logger *slog.Logger,
-) error {
+) (int, error) {
 	var exists bool
 
 	// we check if golang's migrations table already exists, nothing to do if it does
@@ -31,10 +29,10 @@ func migrateMigrationsFromNodejs(
 		schemaName,
 		"schema_migrations",
 	).Scan(&exists); err != nil {
-		return fmt.Errorf("error checking if migrations table exists: %w", err)
+		return 0, fmt.Errorf("error checking if migrations table exists: %w", err)
 	}
 	if exists {
-		return nil
+		return 0, nil
 	}
 
 	// we check if Node.js's migrations table already exists, nothing to do if it doesn't
@@ -43,37 +41,23 @@ func migrateMigrationsFromNodejs(
 		schemaName,
 		"migrations",
 	).Scan(&exists); err != nil {
-		return fmt.Errorf("error checking if migrations table exists: %w", err)
+		return 0, fmt.Errorf("error checking if migrations table exists: %w", err)
 	}
 	if !exists {
-		return nil
+		return 0, nil
 	}
 
-	logger.Info("Migrating from Node.js migrations to Golang migrations")
 	var highestVersion int
 	if err := db.QueryRow(
 		"SELECT MAX(id) FROM auth.migrations",
 	).Scan(&highestVersion); err != nil {
-		return fmt.Errorf("error getting highest migration version: %w", err)
+		return 0, fmt.Errorf("error getting highest migration version: %w", err)
 	}
 
-	logger.Info("Highest migration version found", "version", highestVersion)
-	if err := migration.Force(highestVersion); err != nil {
-		return fmt.Errorf("error forcing migration to version %d: %w", highestVersion, err)
-	}
-
-	// drop the old migrations table - we will do after a while to support downgrades for a while
-	// _, err = db.Exec("DROP TABLE auth.migrations")
-	// if err != nil {
-	// 	return fmt.Errorf("error dropping old migrations table: %w", err)
-	// }
-
-	// logger.Info("Old Node.js migrations table dropped successfully")
-
-	return nil
+	return highestVersion, nil
 }
 
-func ApplyPostgresMigration(postgresURL string, logger *slog.Logger) error {
+func ApplyPostgresMigration(postgresURL string, logger *slog.Logger) error { //nolint:cyclop
 	// for backward compatibility, we ensure that the postgresURL contains the sslmode parameter
 	// if it doesn't, we default to "disable"
 	if !strings.Contains(postgresURL, "sslmode") {
@@ -83,6 +67,11 @@ func ApplyPostgresMigration(postgresURL string, logger *slog.Logger) error {
 	db, err := sql.Open("postgres", postgresURL)
 	if err != nil {
 		return fmt.Errorf("problem connecting to postgres: %w", err)
+	}
+
+	versionToMigrate, err := checkIfWeNeedToMigrate(db)
+	if err != nil {
+		return err
 	}
 
 	driver, err := postgres.WithInstance(
@@ -103,8 +92,11 @@ func ApplyPostgresMigration(postgresURL string, logger *slog.Logger) error {
 		return fmt.Errorf("problem migrations: %w", err)
 	}
 
-	if err := migrateMigrationsFromNodejs(db, migration, logger); err != nil {
-		return fmt.Errorf("problem migrating from Node.js migrations: %w", err)
+	if versionToMigrate > 0 {
+		logger.Info("migrating migrations from node.js to go", "version", versionToMigrate)
+		if err := migration.Force(versionToMigrate); err != nil {
+			return fmt.Errorf("error forcing migration to version %d: %w", versionToMigrate, err)
+		}
 	}
 
 	if err := migration.Up(); err != nil { // or m.Step(2) if you want to explicitly set the number of migrations to run


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Ensure backward compatibility for Postgres `sslmode` in migrations.

- Use correct connection flag for migration command.

- Add legacy `/healthz` endpoints for API prefix compatibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postgres.go</strong><dd><code>Ensure Postgres URL includes sslmode for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/migrations/postgres.go

<li>Add logic to append <code>sslmode=disable</code> if missing in Postgres URL.<br> <li> Enhance migration function for backward compatibility.


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/657/files#diff-a46a7f6d67414014968d95e99e60baf0b0827f7a5ec785a12f9245ddc8d5854b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serve.go</strong><dd><code>Add legacy /healthz endpoints for backward compatibility</code>&nbsp; </dd></summary>
<hr>

go/cmd/serve.go

<li>Add <code>/healthz</code> GET and HEAD endpoints without API prefix for <br>compatibility.<br> <li> Maintain legacy health endpoints alongside prefixed ones.


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/657/files#diff-a900f3187c126bacf5c9c5b1745b5d14bc583c01ab8f1ca84ae449751c224b68">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migrations.go</strong><dd><code>Use correct flag for migration connection string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/cmd/migrations.go

<li>Use <code>flagPostgresMigrationsConnection</code> instead of <br><code>flagPostgresConnection</code>.<br> <li> Fix migration command to use correct connection string.


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/657/files#diff-8902ab7f0135be38b5d4c9e50105df8c79a3f7c4ce73c6006ed9cc751d652a7b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>