### PR TITLE
fix: do not redirect to invalid redirectTo on error to

### DIFF
--- a/go/controller/verify_ticket.go
+++ b/go/controller/verify_ticket.go
@@ -109,7 +109,7 @@ func (ctrl *Controller) getVerifyValidateRequest(
 
 	_, apiErr := ctrl.wf.ValidateOptionsRedirectTo(ctx, options, logger)
 	if apiErr != nil {
-		return sql.AuthUser{}, "", redirectTo, apiErr
+		return sql.AuthUser{}, "", ctrl.config.ClientURL, apiErr
 	}
 
 	ticketType, apiErr := getTicketType(ctx, req.Params.Ticket, logger)

--- a/go/controller/verify_ticket_test.go
+++ b/go/controller/verify_ticket_test.go
@@ -526,6 +526,37 @@ func TestVerifyTicket(t *testing.T) { //nolint:maintidx
 			jwtTokenFn:        nil,
 			getControllerOpts: nil,
 		},
+
+		{
+			name: "wrong redirect URL",
+			config: func() *controller.Config {
+				c := getConfig()
+				c.RequireEmailVerification = true
+				return c
+			},
+			db: func(ctrl *gomock.Controller) controller.DBClient {
+				mock := mock.NewMockDBClient(ctrl)
+
+				return mock
+			},
+			request: api.VerifyTicketRequestObject{
+				Params: api.VerifyTicketParams{
+					Ticket:     "passwordReset:123",
+					RedirectTo: "http://evil.com:3000/redirect",
+					Type:       nil,
+				},
+			},
+			expectedResponse: controller.ErrorRedirectResponse{
+				Headers: struct {
+					Location string
+				}{
+					Location: `http://localhost:3000?error=redirectTo-not-allowed&errorDescription=The+value+of+%22options.redirectTo%22+is+not+allowed.`, //nolint:lll
+				},
+			},
+			expectedJWT:       nil,
+			jwtTokenFn:        nil,
+			getControllerOpts: nil,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
If an attacker requests an invalid redirectTo the service correctly validates the value and throws on error. However, in the case of the /verify endpoint we redirect to the very same redirectTo that we just invalidated indicating the redirectTo was invalid.

### **PR Type**
Bug fix


___

### **Description**
- Fix redirect URL validation in ticket verification

- Prevent redirection to invalid/malicious URLs on error

- Use client URL instead of invalid redirectTo parameter

- Add test case for wrong redirect URL scenario


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invalid redirectTo"] --> B["Validation Error"]
  B --> C["Use ClientURL instead"]
  C --> D["Safe Redirect"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verify_ticket.go</strong><dd><code>Fix redirect URL validation error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/controller/verify_ticket.go

<ul><li>Replace invalid <code>redirectTo</code> with <code>ctrl.config.ClientURL</code> on validation <br>error<br> <li> Prevent potential security vulnerability from malicious redirect URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/664/files#diff-7a36d63db0b247e393d4e7a9a2ff52be673c33aa2a4e40af06f1a4445edb3c32">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verify_ticket_test.go</strong><dd><code>Add test for invalid redirect URL handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go/controller/verify_ticket_test.go

<ul><li>Add test case for "wrong redirect URL" scenario<br> <li> Verify proper error handling with malicious redirect URL<br> <li> Test expected redirect to client URL with appropriate error message</ul>


</details>


  </td>
  <td><a href="https://github.com/nhost/hasura-auth/pull/664/files#diff-0c15b83d87b39bbbb4175ee401fef063bd686677d110c89822ddc287c5f0e57e">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

